### PR TITLE
Disable DDL transactions by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Migrations prefixed with `unsafe_` will warn when invoked. The API is designed t
 
 Migrations prefixed with `safe_` prefer concurrent operations where available, set low lock timeouts where appropriate, and decompose operations into multiple safe steps.
 
+[Running multiple DDL statements inside a transaction acquires exclusive locks on all of the modified objects](https://medium.com/braintree-product-technology/postgresql-at-scale-database-schema-changes-without-downtime-20d3749ed680#cc22). For that reason, this gem [disables DDL transactions](./lib/pg_ha_migrations.rb:8) by default. You can change this by resetting `ActiveRecord::Migration.disable_ddl_transaction` in your application.
+
 The following functionality is currently unsupported:
 
 - Rollbacks
@@ -132,7 +134,7 @@ unsafe_make_column_not_nullable :table, :column
 
 #### safe\_add\_concurrent\_index
 
-Add an index concurrently. Migrations that contain this statement must also include `disable_ddl_transaction!`.
+Add an index concurrently.
 
 ```ruby
 safe_add_concurrent_index :table, :column

--- a/lib/pg_ha_migrations.rb
+++ b/lib/pg_ha_migrations.rb
@@ -27,6 +27,7 @@ require "pg_ha_migrations/unsafe_statements"
 require "pg_ha_migrations/safe_statements"
 require "pg_ha_migrations/allowed_versions"
 require "pg_ha_migrations/railtie"
+require "pg_ha_migrations/hacks/disable_ddl_transaction"
 
 module PgHaMigrations::AutoIncluder
   def inherited(klass)

--- a/lib/pg_ha_migrations/hacks/disable_ddl_transaction.rb
+++ b/lib/pg_ha_migrations/hacks/disable_ddl_transaction.rb
@@ -1,0 +1,15 @@
+require "active_record/migration"
+
+module PgHaMigrations
+  module ActiveRecordHacks
+    module DisableDdlTransaction
+      def disable_ddl_transaction
+        # Default to disabled unless someone has set it elsewhere
+        defined?(@disable_ddl_transaction) ? @disable_ddl_transaction : true
+      end
+    end
+  end
+end
+
+ActiveRecord::Migration.singleton_class.prepend(PgHaMigrations::ActiveRecordHacks::DisableDdlTransaction)
+

--- a/spec/pg_ha_migrations_spec.rb
+++ b/spec/pg_ha_migrations_spec.rb
@@ -1,6 +1,10 @@
 require "spec_helper"
 
 RSpec.describe PgHaMigrations do
+  it "disables ddl transactions" do
+    expect(ActiveRecord::Migration.disable_ddl_transaction).to be_truthy
+  end
+
   PgHaMigrations::AllowedVersions::ALLOWED_VERSIONS.each do |migration_klass|
     describe "interaction with ActiveRecord::Migration::Compatibility inheritance hierarchy with #{migration_klass.name}" do
       let(:subclass) { Class.new(migration_klass) }


### PR DESCRIPTION
@JonMR and I were working a few weeks ago on adding this gem to an existing application. We came across the realization that this library should disable DDL transactions by default.

ActiveRecord uses DDL transactions by default; this means that every migration is wrapped in a transaction. If the migration in question alters multiple objects, it will likely acquire exclusive locks on all of those objects, all within one transaction, which can decrease availability in non-trivial ways. Rather than attempt to track or prevent a single migration with "too many" objects altered, we opt to avoid running migrations in a transaction by setting ActiveRecord's `disable_ddl_transations` to true by default. [This blog post has more detailed information](https://medium.com/braintree-product-technology/postgresql-at-scale-database-schema-changes-without-downtime-20d3749ed680).

This change also makes running `safe_add_concurrent_index` possible without having to manually disable ddl transactions on a per migration basis.

One this to bear in mind, however, is that with ddl transactions disabled by default, the changeset in one migration is no longer atomic. This allows a migration to fail part-way through.

An application can override our library's default, setting it back to *enabling* ddl transactions; we have added a reference to how to do so in the README.