### PR TITLE
cleanup- remove duplicate log statement per PR#6 feedback

### DIFF
--- a/lib/pg_ha_migrations/unsafe_statements.rb
+++ b/lib/pg_ha_migrations/unsafe_statements.rb
@@ -1,11 +1,7 @@
 module PgHaMigrations::UnsafeStatements
   def self.delegate_unsafe_method_to_connection(method_name)
     define_method("unsafe_#{method_name}") do |*args, &block|
-      arg_list = args.map { |arg| arg.inspect }.join(', ')
-      # say_with_time args taken from https://github.com/rails/rails/blob/4-2-stable/activerecord/lib/active_record/migration.rb#L654
-      say_with_time "#{method_name}(#{arg_list})" do
         self.class.superclass.send(method_name, *args, &block)
-      end
     end
   end
 


### PR DESCRIPTION
I merged a PR before collecting thorough feedback! Apologies.

@jcoleman had some good feedback in https://github.com/braintreeps/pg_ha_migrations/pull/6 about removing a duplicate log statement. This PR does that.

I tested the output, and confirmed that `say_with_time` does print part of the log twice.

With `say_with_time`:
```
==  : migrating ===============================================================\n-- create_table(:foos)\n-- create_table(:foos)\n   -> 0.0047s\n   -> 0.0048s\n==  : migrated (0.0048s) =============
```

without:
```
==  : migrating ===============================================================\n-- create_table(:foos)\n   -> 0.0038s\n==  : migrated (0.0039s) ======================================================
```

I don't think it is necessarily worthwhile to update the spec to catch this kind of difference, but if anyone else thinks it's a good idea, I'll be happy to make that change as well.