### PR TITLE
Fix ActiveRecord migration compatibility inheritance, part 2

### DIFF
--- a/lib/pg_ha_migrations.rb
+++ b/lib/pg_ha_migrations.rb
@@ -28,7 +28,13 @@ require "pg_ha_migrations/safe_statements"
 require "pg_ha_migrations/allowed_versions"
 require "pg_ha_migrations/railtie"
 
-PgHaMigrations::AllowedVersions::ALLOWED_VERSIONS.each do |migrations_class|
-  migrations_class.prepend(PgHaMigrations::SafeStatements)
-  migrations_class.prepend(PgHaMigrations::UnsafeStatements)
+module PgHaMigrations::AutoIncluder
+  def inherited(klass)
+    super(klass) if defined?(super)
+
+    klass.prepend(PgHaMigrations::SafeStatements)
+    klass.prepend(PgHaMigrations::UnsafeStatements)
+  end
 end
+
+ActiveRecord::Migration.singleton_class.prepend(PgHaMigrations::AutoIncluder)

--- a/lib/pg_ha_migrations/unsafe_statements.rb
+++ b/lib/pg_ha_migrations/unsafe_statements.rb
@@ -9,10 +9,10 @@ module PgHaMigrations::UnsafeStatements
       # is not implemented in real methods but rather by proxying.
       #
       # For example, ActiveRecord::Migration doesn't define #create_table.
-      # Instead ActiveRecord::Migration#method_missing proxies the  method
+      # Instead ActiveRecord::Migration#method_missing proxies the method
       # to the connection. However some migration compatibility version
-      # subclasses do doesn't explicitly define #create_table, so we can't
-      # solely rely on only one way of finding the proper dispatch target.
+      # subclasses _do_ explicitly define #create_table, so we can't rely
+      # on only one way of finding the proper dispatch target.
 
       # Exclude our `raise` guard implementations.
       ancestors_without_unsafe_statements = self.class.ancestors - [PgHaMigrations::UnsafeStatements]

--- a/lib/pg_ha_migrations/unsafe_statements.rb
+++ b/lib/pg_ha_migrations/unsafe_statements.rb
@@ -1,45 +1,78 @@
 module PgHaMigrations::UnsafeStatements
-  def self.delegate_unsafe_method_to_connection(method_name)
+  def self.delegate_unsafe_method_to_migration_base_class(method_name)
     define_method("unsafe_#{method_name}") do |*args, &block|
-      arg_list = args.map { |arg| arg.inspect }.join(', ')
-      # say_with_time args taken from https://github.com/rails/rails/blob/4-2-stable/activerecord/lib/active_record/migration.rb#L654
-      say_with_time "#{method_name}(#{arg_list})" do
-        self.class.superclass.send(method_name, *args, &block)
+      # Dispatching here is a bit complicated: we need to execute the method
+      # belonging to the first member of the inheritance chain (besides
+      # UnsafeStatements). If don't find the method in the inheritance chain,
+      # we need to rely on the ActiveRecord::Migration#method_missing
+      # implementation since much of ActiveRecord::Migration's functionality
+      # is not implemented in real methods but rather by proxying.
+      #
+      # For example, ActiveRecord::Migration doesn't define #create_table.
+      # Instead ActiveRecord::Migration#method_missing proxies the  method
+      # to the connection. However some migration compatibility version
+      # subclasses do doesn't explicitly define #create_table, so we can't
+      # solely rely on only one way of finding the proper dispatch target.
+
+      # Exclude our `raise` guard implementations.
+      ancestors_without_unsafe_statements = self.class.ancestors - [PgHaMigrations::UnsafeStatements]
+
+      delegate_method = self.method(method_name)
+      candidate_method = delegate_method
+
+      # Find the first usable method in the ancestor chain
+      # or stop looking if there are no more possible
+      # implementations.
+      until candidate_method.nil? || ancestors_without_unsafe_statements.include?(candidate_method.owner)
+        candidate_method = candidate_method.super_method
+      end
+
+      if candidate_method
+        delegate_method = candidate_method
+      end
+
+      # If we failed to find a concrete implementation from the
+      # inheritance chain, use ActiveRecord::Migrations# method_missing
+      # otherwise use the method from the inheritance chain.
+      if delegate_method.owner == PgHaMigrations::UnsafeStatements
+        method_missing(method_name, *args, &block)
+      else
+        delegate_method.call(*args, &block)
       end
     end
   end
 
-  delegate_unsafe_method_to_connection :create_table
+  delegate_unsafe_method_to_migration_base_class :create_table
   def create_table(name, options={})
     raise PgHaMigrations::UnsafeMigrationError.new(":create_table is NOT SAFE! Use safe_create_table instead")
   end
 
-  delegate_unsafe_method_to_connection :add_column
+  delegate_unsafe_method_to_migration_base_class :add_column
   def add_column(table, column, type, options={})
     raise PgHaMigrations::UnsafeMigrationError.new(":add_column is NOT SAFE! Use safe_add_column instead")
   end
 
-  delegate_unsafe_method_to_connection :change_table
+  delegate_unsafe_method_to_migration_base_class :change_table
   def change_table(name, options={})
     raise PgHaMigrations::UnsafeMigrationError.new(":change_table is NOT SAFE! Use a combination of safe and explicit unsafe migration methods instead")
   end
 
-  delegate_unsafe_method_to_connection :drop_table
+  delegate_unsafe_method_to_migration_base_class :drop_table
   def drop_table(name)
     raise PgHaMigrations::UnsafeMigrationError.new(":drop_table is NOT SAFE! Explicitly call :unsafe_drop_table to proceed")
   end
 
-  delegate_unsafe_method_to_connection :rename_table
+  delegate_unsafe_method_to_migration_base_class :rename_table
   def rename_table(old_name, new_name)
     raise PgHaMigrations::UnsafeMigrationError.new(":rename_table is NOT SAFE! Explicitly call :unsafe_rename_table to proceed")
   end
 
-  delegate_unsafe_method_to_connection :rename_column
+  delegate_unsafe_method_to_migration_base_class :rename_column
   def rename_column(table_name, column_name, new_column_name)
     raise PgHaMigrations::UnsafeMigrationError.new(":rename_column is NOT SAFE! Explicitly call :unsafe_rename_column to proceed")
   end
 
-  delegate_unsafe_method_to_connection :change_column
+  delegate_unsafe_method_to_migration_base_class :change_column
   def change_column(table_name, column_name, type, options={})
     raise PgHaMigrations::UnsafeMigrationError.new(":change_column is NOT SAFE! Use a combination of safe and explicit unsafe migration methods instead")
   end
@@ -50,27 +83,31 @@ module PgHaMigrations::UnsafeStatements
     EOS
   end
 
-  delegate_unsafe_method_to_connection :remove_column
+  delegate_unsafe_method_to_migration_base_class :remove_column
   def remove_column(table_name, column_name, type, options={})
     raise PgHaMigrations::UnsafeMigrationError.new(":remove_column is NOT SAFE! Explicitly call :unsafe_remove_column to proceed")
   end
 
-  delegate_unsafe_method_to_connection :add_index
+  delegate_unsafe_method_to_migration_base_class :add_index
   def add_index(table_name, column_names, options={})
     raise PgHaMigrations::UnsafeMigrationError.new(":add_index is NOT SAFE! Use safe_add_concurrent_index instead")
   end
 
-  delegate_unsafe_method_to_connection :execute
+  delegate_unsafe_method_to_migration_base_class :execute
   def execute(sql, name = nil)
-    raise PgHaMigrations::UnsafeMigrationError.new(":execute is NOT SAFE! Explicitly call :unsafe_execute to proceed")
+    if caller[0] =~ /lib\/active_record\/migration\/compatibility.rb/
+      super
+    else
+      raise PgHaMigrations::UnsafeMigrationError.new(":execute is NOT SAFE! Explicitly call :unsafe_execute to proceed")
+    end
   end
 
-  delegate_unsafe_method_to_connection :remove_index
+  delegate_unsafe_method_to_migration_base_class :remove_index
   def remove_index(table_name, options={})
     raise PgHaMigrations::UnsafeMigrationError.new(":remove_index is NOT SAFE! Use safe_remove_concurrent_index instead for Postgres 9.6 databases; Explicitly call :unsafe_remove_index to proceed on Postgres 9.1")
   end
 
-  delegate_unsafe_method_to_connection :add_foreign_key
+  delegate_unsafe_method_to_migration_base_class :add_foreign_key
   def add_foreign_key(from_table, to_table, options)
     raise PgHaMigrations::UnsafeMigrationError.new(":add_foreign_key is NOT SAFE! Explicitly call :unsafe_add_foreign_key only if you have guidance from a migration reviewer in #service-app-db.")
   end

--- a/spec/pg_ha_migrations_spec.rb
+++ b/spec/pg_ha_migrations_spec.rb
@@ -1,54 +1,87 @@
 require "spec_helper"
 
 RSpec.describe PgHaMigrations do
-  describe "prepends itself to the compatibility classes" do
-    {
-      4.2 =>  [
-        PgHaMigrations::UnsafeStatements,
-        PgHaMigrations::SafeStatements,
-        ActiveRecord::Migration::Compatibility::V4_2,
-        PgHaMigrations::UnsafeStatements,
-        PgHaMigrations::SafeStatements,
-        ActiveRecord::Migration::Compatibility::V5_0,
-        PgHaMigrations::UnsafeStatements,
-        PgHaMigrations::SafeStatements,
-        ActiveRecord::Migration::Compatibility::V5_1,
-        PgHaMigrations::UnsafeStatements,
-        PgHaMigrations::SafeStatements,
-        ActiveRecord::Migration::Current,
-        ActiveRecord::Migration,
-      ],
-      5.0 => [
-        PgHaMigrations::UnsafeStatements,
-        PgHaMigrations::SafeStatements,
-        ActiveRecord::Migration::Compatibility::V5_0,
-        PgHaMigrations::UnsafeStatements,
-        PgHaMigrations::SafeStatements,
-        ActiveRecord::Migration::Compatibility::V5_1,
-        PgHaMigrations::UnsafeStatements,
-        PgHaMigrations::SafeStatements,
-        ActiveRecord::Migration::Current,
-        ActiveRecord::Migration,
-      ],
-      5.1 => [
-        PgHaMigrations::UnsafeStatements,
-        PgHaMigrations::SafeStatements,
-        ActiveRecord::Migration::Compatibility::V5_1,
-        PgHaMigrations::UnsafeStatements,
-        PgHaMigrations::SafeStatements,
-        ActiveRecord::Migration::Current,
-        ActiveRecord::Migration,
-      ],
-      5.2 => [
-        PgHaMigrations::UnsafeStatements,
-        PgHaMigrations::SafeStatements,
-        ActiveRecord::Migration::Current,
-        ActiveRecord::Migration,
-      ]
-    }.each do |version, inheritance_chain|
-      it "has the correct inheritance chain in #{version}" do
-        foo = Class.new(ActiveRecord::Migration[version])
-        expect(foo.ancestors[1..-1]).to start_with(inheritance_chain)
+  PgHaMigrations::AllowedVersions::ALLOWED_VERSIONS.each do |migration_klass|
+    describe "interaction with ActiveRecord::Migration::Compatibility inheritance hierarchy with #{migration_klass.name}" do
+      let(:subclass) { Class.new(migration_klass) }
+
+      it "prepends PgHaMigrations modules to the inherited class" do
+        expect(subclass.ancestors[0..1]).to eq([
+          PgHaMigrations::UnsafeStatements,
+          PgHaMigrations::SafeStatements,
+        ])
+      end
+
+      it "does not include the module more than once" do
+        included_modules = subclass.ancestors.select do |ancestor|
+          [
+            PgHaMigrations::UnsafeStatements,
+            PgHaMigrations::SafeStatements,
+          ].include?(ancestor)
+        end
+
+        expect(included_modules.size).to eq(2)
+      end
+
+      describe "method lookup" do
+        around(:each) do |example|
+          @instance_methods_by_class = [
+            PgHaMigrations::UnsafeStatements,
+            PgHaMigrations::SafeStatements,
+            migration_klass,
+          ].each_with_object({}) do |klass, hash|
+            hash[klass] = klass.instance_methods
+          end
+
+          PgHaMigrations::UnsafeStatements.class_eval do
+            delegate_unsafe_method_to_migration_base_class(:pg_ha_migrations_test_method)
+            def pg_ha_migrations_test_method
+              raise "unexpected execution of unsafe method"
+            end
+          end
+
+          begin
+            example.run
+          ensure
+            PgHaMigrations::UnsafeStatements.send(:remove_method, :pg_ha_migrations_test_method)
+            PgHaMigrations::UnsafeStatements.send(:remove_method, :unsafe_pg_ha_migrations_test_method)
+          end
+
+          # Make sure we clean up after ourselves since these tests have to
+          # do some dirty poisoning of the classes and modules under test.
+          @instance_methods_by_class.each do |klass, methods|
+            expect(klass.instance_methods).to match_array(methods)
+          end
+        end
+
+        it "executes a method from the versioned superclass" do
+          # We intentionally avoid using any RSpec mocking here because
+          # we need to to be absolutely certain that we've defined this
+          # method _directly_ on the class we inherit from.
+          begin
+            migration_klass.class_eval do
+              def pg_ha_migrations_test_method
+                "sentinel_value"
+              end
+            end
+
+            expect(subclass.new.unsafe_pg_ha_migrations_test_method).to eq("sentinel_value")
+          ensure
+            migration_klass.send(:remove_method, :pg_ha_migrations_test_method)
+            expect(migration_klass.instance_methods).not_to include(:pg_ha_migrations_test_method)
+          end
+        end
+
+        it "executes a magic method on the versioned superclass" do
+          # Rails is _very_ smart and implements a lot of migration's
+          # functionality via Ruby metaprogramming's method_missing.
+          # This is...a major annoyance, but...
+          #
+          # Because our method now lives outside of the inheritance
+          # hierarchy we can go back to using RSpec's method mocking.
+          expect(ActiveRecord::Base.connection).to receive(:pg_ha_migrations_test_method).and_return("sentinel_value")
+          expect(subclass.new.unsafe_pg_ha_migrations_test_method).to eq("sentinel_value")
+        end
       end
     end
   end


### PR DESCRIPTION
ActiveRecord implements version backwards compatibility for migrations
via per-migration version subclasses. This is rather at odds with our
strategy of prepending overrides, since it's not obvious where to put
our modules in the ancestor chain. For example, if we put it at the
bottom, only migrations of the oldest compatibility version will
benefit, but if we prepend on every version subclass the modules will be
in ancestors multiple times for the lower version subclasses.

Since most of migration's functionality is implemented as instance
methods we can't rely on delegating to the superclass (though
confusingly the migration class makes this appear to work), and we have
to maintain per-version implementation details anyway (so calling one
class up with the overrides prepended on every version can end up
unintentionally triggering our `raise` guard methods).

To be able to maintain our goals of:
1. Preventing non-explicit uses of original/unsafe implementations, and
2. Wrapping (instead of re-implementing) the unsafe implementations
we need to be able to access the original implementation while still not
having the original method directly available.

Further complicating things much of `ActiveRecord::Migration`'s
functionality isn't actually implemented on `Migration` directly;
instead `ActiveRecord::Migration` proxies it to the connection via
`method_missing`.

One possible solution would be to implement our own versioned subclasses
and require migrations to inherit from those classes. But that would
break our design goal of making it difficult to use the original unsafe
implementations without communicating explicit intent to do so.

The only implementation that seems to satisfy all of the goals above is
to apply the overrides on a per-application-migration-subclass level and
implement some reasonable complicated method dispatch logic for finding
the original implementation we want to wrap with our safety guards.

Co-authored-by: Celeen <celeen@users.noreply.github.com>