### PR TITLE
Update Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: false
 language: ruby
 rvm:
-  - 1.9.3
+  - 2.4
 before_install: gem install bundler -v 1.15.4


### PR DESCRIPTION
Just the Ruby version now in preparation for enabling public Travis builds.