### PR TITLE
Allow users to re-enable default migration methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ and never use `def change`. We believe that this is the only safe approach in pr
 
 ### Migrations
 
-In general, existing migrations are prefixed with `unsafe_` and safer alternatives are provided prefixed with `safe_`. 
+In general, existing migrations are prefixed with `unsafe_` and safer alternatives are provided prefixed with `safe_`.
 
 Migrations prefixed with `unsafe_` will warn when invoked. The API is designed to be explicit yet remain flexible. There may be situations where invoking the unsafe migration is preferred.
 
@@ -195,6 +195,19 @@ Set maintenance work mem.
 safe_set_maintenance_work_mem_gb 1
 ```
 
+### Configuration
+
+The gem can be configured in an initializer.
+
+```ruby
+PgHaMigrations.configure do |config|
+  # ...
+end
+```
+
+#### Available options
+
+- `disable_default_migration_methods`: If true, the default implementations of DDL changes in `ActiveRecord::Migration` and the PostgreSQL adapter will be overridden by implementations that raise a `PgHaMigrations::UnsafeMigrationError`. Default: `true`
 
 ### Rake Tasks
 

--- a/lib/pg_ha_migrations.rb
+++ b/lib/pg_ha_migrations.rb
@@ -5,6 +5,16 @@ require "active_record/migration"
 require "relation_to_struct"
 
 module PgHaMigrations
+  Config = Struct.new(:disable_default_migration_methods)
+
+  def self.config
+    @config ||= Config.new(true)
+  end
+
+  def self.configure
+    yield config
+  end
+
   LOCK_TIMEOUT_SECONDS = 5
   LOCK_FAILURE_RETRY_DELAY_MULTLIPLIER = 5
 

--- a/lib/pg_ha_migrations/unsafe_statements.rb
+++ b/lib/pg_ha_migrations/unsafe_statements.rb
@@ -1,114 +1,93 @@
 module PgHaMigrations::UnsafeStatements
+  def self.disable_or_delegate_default_method(method_name, error_message, allow_reentry_from_compatibility_module: false)
+    define_method(method_name) do |*args, &block|
+      if PgHaMigrations.config.disable_default_migration_methods
+        # Most migration methods are only ever called by a migration and
+        # therefore aren't re-entrant or callable from another migration
+        # method, but `execute` is called directly by at least one of the
+        # implementations in `ActiveRecord::Migration::Compatibility` so
+        # we have to explicitly handle that case by allowing execution of
+        # the original implementation by its original name.
+        unless  allow_reentry_from_compatibility_module && caller[0] =~ /lib\/active_record\/migration\/compatibility.rb/
+          raise PgHaMigrations::UnsafeMigrationError, error_message
+        end
+      end
+
+      execute_ancestor_statement(method_name, *args, &block)
+    end
+  end
+
   def self.delegate_unsafe_method_to_migration_base_class(method_name)
     define_method("unsafe_#{method_name}") do |*args, &block|
-      # Dispatching here is a bit complicated: we need to execute the method
-      # belonging to the first member of the inheritance chain (besides
-      # UnsafeStatements). If don't find the method in the inheritance chain,
-      # we need to rely on the ActiveRecord::Migration#method_missing
-      # implementation since much of ActiveRecord::Migration's functionality
-      # is not implemented in real methods but rather by proxying.
-      #
-      # For example, ActiveRecord::Migration doesn't define #create_table.
-      # Instead ActiveRecord::Migration#method_missing proxies the method
-      # to the connection. However some migration compatibility version
-      # subclasses _do_ explicitly define #create_table, so we can't rely
-      # on only one way of finding the proper dispatch target.
-
-      # Exclude our `raise` guard implementations.
-      ancestors_without_unsafe_statements = self.class.ancestors - [PgHaMigrations::UnsafeStatements]
-
-      delegate_method = self.method(method_name)
-      candidate_method = delegate_method
-
-      # Find the first usable method in the ancestor chain
-      # or stop looking if there are no more possible
-      # implementations.
-      until candidate_method.nil? || ancestors_without_unsafe_statements.include?(candidate_method.owner)
-        candidate_method = candidate_method.super_method
-      end
-
-      if candidate_method
-        delegate_method = candidate_method
-      end
-
-      # If we failed to find a concrete implementation from the
-      # inheritance chain, use ActiveRecord::Migrations# method_missing
-      # otherwise use the method from the inheritance chain.
-      if delegate_method.owner == PgHaMigrations::UnsafeStatements
-        method_missing(method_name, *args, &block)
-      else
-        delegate_method.call(*args, &block)
-      end
+      execute_ancestor_statement(method_name, *args, &block)
     end
   end
 
   delegate_unsafe_method_to_migration_base_class :create_table
-  def create_table(name, options={})
-    raise PgHaMigrations::UnsafeMigrationError.new(":create_table is NOT SAFE! Use safe_create_table instead")
-  end
-
   delegate_unsafe_method_to_migration_base_class :add_column
-  def add_column(table, column, type, options={})
-    raise PgHaMigrations::UnsafeMigrationError.new(":add_column is NOT SAFE! Use safe_add_column instead")
-  end
-
   delegate_unsafe_method_to_migration_base_class :change_table
-  def change_table(name, options={})
-    raise PgHaMigrations::UnsafeMigrationError.new(":change_table is NOT SAFE! Use a combination of safe and explicit unsafe migration methods instead")
-  end
-
   delegate_unsafe_method_to_migration_base_class :drop_table
-  def drop_table(name)
-    raise PgHaMigrations::UnsafeMigrationError.new(":drop_table is NOT SAFE! Explicitly call :unsafe_drop_table to proceed")
-  end
-
   delegate_unsafe_method_to_migration_base_class :rename_table
-  def rename_table(old_name, new_name)
-    raise PgHaMigrations::UnsafeMigrationError.new(":rename_table is NOT SAFE! Explicitly call :unsafe_rename_table to proceed")
-  end
-
   delegate_unsafe_method_to_migration_base_class :rename_column
-  def rename_column(table_name, column_name, new_column_name)
-    raise PgHaMigrations::UnsafeMigrationError.new(":rename_column is NOT SAFE! Explicitly call :unsafe_rename_column to proceed")
-  end
-
   delegate_unsafe_method_to_migration_base_class :change_column
-  def change_column(table_name, column_name, type, options={})
-    raise PgHaMigrations::UnsafeMigrationError.new(":change_column is NOT SAFE! Use a combination of safe and explicit unsafe migration methods instead")
-  end
-
-  def change_column_null(table_name, column_name, null, default = nil)
-    raise PgHaMigrations::UnsafeMigrationError.new(<<-EOS.strip_heredoc)
-    :change_column_null is NOT (guaranteed to be) SAFE! Either use :safe_make_column_nullable or explicitly call :unsafe_make_column_not_nullable to proceed
-    EOS
-  end
-
   delegate_unsafe_method_to_migration_base_class :remove_column
-  def remove_column(table_name, column_name, type, options={})
-    raise PgHaMigrations::UnsafeMigrationError.new(":remove_column is NOT SAFE! Explicitly call :unsafe_remove_column to proceed")
-  end
-
   delegate_unsafe_method_to_migration_base_class :add_index
-  def add_index(table_name, column_names, options={})
-    raise PgHaMigrations::UnsafeMigrationError.new(":add_index is NOT SAFE! Use safe_add_concurrent_index instead")
-  end
-
   delegate_unsafe_method_to_migration_base_class :execute
-  def execute(sql, name = nil)
-    if caller[0] =~ /lib\/active_record\/migration\/compatibility.rb/
-      super
-    else
-      raise PgHaMigrations::UnsafeMigrationError.new(":execute is NOT SAFE! Explicitly call :unsafe_execute to proceed")
-    end
-  end
-
   delegate_unsafe_method_to_migration_base_class :remove_index
-  def remove_index(table_name, options={})
-    raise PgHaMigrations::UnsafeMigrationError.new(":remove_index is NOT SAFE! Use safe_remove_concurrent_index instead for Postgres 9.6 databases; Explicitly call :unsafe_remove_index to proceed on Postgres 9.1")
-  end
-
   delegate_unsafe_method_to_migration_base_class :add_foreign_key
-  def add_foreign_key(from_table, to_table, options)
-    raise PgHaMigrations::UnsafeMigrationError.new(":add_foreign_key is NOT SAFE! Explicitly call :unsafe_add_foreign_key only if you have guidance from a migration reviewer in #service-app-db.")
+
+  disable_or_delegate_default_method :create_table, ":create_table is NOT SAFE! Use safe_create_table instead"
+  disable_or_delegate_default_method :add_column, ":add_column is NOT SAFE! Use safe_add_column instead"
+  disable_or_delegate_default_method :change_table, ":change_table is NOT SAFE! Use a combination of safe and explicit unsafe migration methods instead"
+  disable_or_delegate_default_method :drop_table, ":drop_table is NOT SAFE! Explicitly call :unsafe_drop_table to proceed"
+  disable_or_delegate_default_method :rename_table, ":rename_table is NOT SAFE! Explicitly call :unsafe_rename_table to proceed"
+  disable_or_delegate_default_method :rename_column, ":rename_column is NOT SAFE! Explicitly call :unsafe_rename_column to proceed"
+  disable_or_delegate_default_method :change_column, ":change_column is NOT SAFE! Use a combination of safe and explicit unsafe migration methods instead"
+  disable_or_delegate_default_method :change_column_null, ":change_column_null is NOT (guaranteed to be) SAFE! Either use :safe_make_column_nullable or explicitly call :unsafe_make_column_not_nullable to proceed"
+  disable_or_delegate_default_method :remove_column, ":remove_column is NOT SAFE! Explicitly call :unsafe_remove_column to proceed"
+  disable_or_delegate_default_method :add_index, ":add_index is NOT SAFE! Use safe_add_concurrent_index instead"
+  disable_or_delegate_default_method :execute, ":execute is NOT SAFE! Explicitly call :unsafe_execute to proceed", allow_reentry_from_compatibility_module: true
+  disable_or_delegate_default_method :remove_index, ":remove_index is NOT SAFE! Use safe_remove_concurrent_index instead for Postgres 9.6 databases; Explicitly call :unsafe_remove_index to proceed on Postgres 9.1"
+  disable_or_delegate_default_method :add_foreign_key, ":add_foreign_key is NOT SAFE! Explicitly call :unsafe_add_foreign_key only if you have guidance from a migration reviewer in #service-app-db."
+
+  def execute_ancestor_statement(method_name, *args, &block)
+    # Dispatching here is a bit complicated: we need to execute the method
+    # belonging to the first member of the inheritance chain (besides
+    # UnsafeStatements). If don't find the method in the inheritance chain,
+    # we need to rely on the ActiveRecord::Migration#method_missing
+    # implementation since much of ActiveRecord::Migration's functionality
+    # is not implemented in real methods but rather by proxying.
+    #
+    # For example, ActiveRecord::Migration doesn't define #create_table.
+    # Instead ActiveRecord::Migration#method_missing proxies the method
+    # to the connection. However some migration compatibility version
+    # subclasses _do_ explicitly define #create_table, so we can't rely
+    # on only one way of finding the proper dispatch target.
+
+    # Exclude our `raise` guard implementations.
+    ancestors_without_unsafe_statements = self.class.ancestors - [PgHaMigrations::UnsafeStatements]
+
+    delegate_method = self.method(method_name)
+    candidate_method = delegate_method
+
+    # Find the first usable method in the ancestor chain
+    # or stop looking if there are no more possible
+    # implementations.
+    until candidate_method.nil? || ancestors_without_unsafe_statements.include?(candidate_method.owner)
+      candidate_method = candidate_method.super_method
+    end
+
+    if candidate_method
+      delegate_method = candidate_method
+    end
+
+    # If we failed to find a concrete implementation from the
+    # inheritance chain, use ActiveRecord::Migrations# method_missing
+    # otherwise use the method from the inheritance chain.
+    if delegate_method.owner == PgHaMigrations::UnsafeStatements
+      method_missing(method_name, *args, &block)
+    else
+      delegate_method.call(*args, &block)
+    end
   end
 end

--- a/spec/pg_ha_migrations_spec.rb
+++ b/spec/pg_ha_migrations_spec.rb
@@ -5,6 +5,34 @@ RSpec.describe PgHaMigrations do
     expect(ActiveRecord::Migration.disable_ddl_transaction).to be_truthy
   end
 
+  describe "config" do
+    after(:each) do
+      PgHaMigrations.instance_variable_set(:@config, nil)
+    end
+
+    context "disable_default_migration_methods" do
+      context "by default" do
+        it "is set to true" do
+          expect(PgHaMigrations.config.disable_default_migration_methods)
+            .to be(true)
+        end
+      end
+
+      context "overridden to be false" do
+        before(:each) do
+          PgHaMigrations.configure do |config|
+            config.disable_default_migration_methods = false
+          end
+        end
+
+        it "is set to false" do
+          expect(PgHaMigrations.config.disable_default_migration_methods)
+            .to be(false)
+        end
+      end
+    end
+  end
+
   PgHaMigrations::AllowedVersions::ALLOWED_VERSIONS.each do |migration_klass|
     describe "interaction with ActiveRecord::Migration::Compatibility inheritance hierarchy with #{migration_klass.name}" do
       let(:subclass) { Class.new(migration_klass) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,19 +16,19 @@ RSpec.configure do |config|
 
   config.before(:all) do
     ActiveRecord::Base.connection.tables.each do |table|
-      ActiveRecord::Base.connection.execute("DROP TABLE #{table}")
+      ActiveRecord::Base.connection.execute("DROP TABLE #{table} CASCADE")
     end
     ActiveRecord::Base.connection.select_values("SELECT typname FROM pg_type WHERE typtype = 'e'").each do |enum|
-      ActiveRecord::Base.connection.execute("DROP TYPE #{enum}")
+      ActiveRecord::Base.connection.execute("DROP TYPE #{enum} CASCADE")
     end
   end
 
   config.after(:each) do
     ActiveRecord::Base.connection.tables.each do |table|
-      ActiveRecord::Base.connection.execute("DROP TABLE #{table}")
+      ActiveRecord::Base.connection.execute("DROP TABLE #{table} CASCADE")
     end
     ActiveRecord::Base.connection.select_values("SELECT typname FROM pg_type WHERE typtype = 'e'").each do |enum|
-      ActiveRecord::Base.connection.execute("DROP TYPE #{enum}")
+      ActiveRecord::Base.connection.execute("DROP TYPE #{enum} CASCADE")
     end
   end
 


### PR DESCRIPTION
Fixes #17.

It turns out that looking up the default implementation for this purpose is quite as tricky as it is when aliasing to `unsafe_$FOO` so the implementation is essentially to introduce a very similar method to `delegate_unsafe_method_to_migration_base_class` and pull out the shared part to a helper.

There's a couple of failing tests but these seem to be also failing on master (related to creating indexes concurrently) and unrelated to this PR.