### PR TITLE
Add configuration option for disabling DDL transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ end
 #### Available options
 
 - `disable_default_migration_methods`: If true, the default implementations of DDL changes in `ActiveRecord::Migration` and the PostgreSQL adapter will be overridden by implementations that raise a `PgHaMigrations::UnsafeMigrationError`. Default: `true`
+- `disable_ddl_transactions`: If true, migrations will not run in a DDL transaction, helping to avoid situations where locks are acquired on many objects at once. Default: `true`
 
 ### Rake Tasks
 

--- a/lib/pg_ha_migrations.rb
+++ b/lib/pg_ha_migrations.rb
@@ -7,6 +7,7 @@ require "relation_to_struct"
 
 module PgHaMigrations
   DEFAULT_CONFIG = {
+    disable_ddl_transactions: true,
     disable_default_migration_methods: true,
   }
 

--- a/lib/pg_ha_migrations.rb
+++ b/lib/pg_ha_migrations.rb
@@ -1,14 +1,17 @@
 require "pg_ha_migrations/version"
+require "pg_ha_migrations/config"
 require "rails"
 require "active_record"
 require "active_record/migration"
 require "relation_to_struct"
 
 module PgHaMigrations
-  Config = Struct.new(:disable_default_migration_methods)
+  DEFAULT_CONFIG = {
+    disable_default_migration_methods: true,
+  }
 
   def self.config
-    @config ||= Config.new(true)
+    @config ||= Config.new(**DEFAULT_CONFIG)
   end
 
   def self.configure

--- a/lib/pg_ha_migrations/config.rb
+++ b/lib/pg_ha_migrations/config.rb
@@ -1,0 +1,9 @@
+module PgHaMigrations
+  class Config
+    attr_accessor :disable_default_migration_methods
+
+    def initialize(disable_default_migration_methods:)
+      @disable_default_migration_methods = disable_default_migration_methods
+    end
+  end
+end

--- a/lib/pg_ha_migrations/config.rb
+++ b/lib/pg_ha_migrations/config.rb
@@ -1,9 +1,12 @@
 module PgHaMigrations
   class Config
-    attr_accessor :disable_default_migration_methods
+    attr_accessor :disable_default_migration_methods,
+                  :disable_ddl_transactions
 
-    def initialize(disable_default_migration_methods:)
+    def initialize(disable_default_migration_methods:,
+                   disable_ddl_transactions:)
       @disable_default_migration_methods = disable_default_migration_methods
+      @disable_ddl_transactions = disable_ddl_transactions
     end
   end
 end

--- a/lib/pg_ha_migrations/hacks/disable_ddl_transaction.rb
+++ b/lib/pg_ha_migrations/hacks/disable_ddl_transaction.rb
@@ -4,8 +4,12 @@ module PgHaMigrations
   module ActiveRecordHacks
     module DisableDdlTransaction
       def disable_ddl_transaction
-        # Default to disabled unless someone has set it elsewhere
-        defined?(@disable_ddl_transaction) ? @disable_ddl_transaction : true
+        # Use configured default unless someone has set it elsewhere
+        if defined?(@disable_ddl_transaction)
+          @disable_ddl_transaction
+        else
+          PgHaMigrations.config.disable_ddl_transactions
+        end
       end
     end
   end

--- a/lib/pg_ha_migrations/safe_statements.rb
+++ b/lib/pg_ha_migrations/safe_statements.rb
@@ -104,6 +104,12 @@ module PgHaMigrations::SafeStatements
 
   def safely_acquire_lock_for_table(table, &block)
     _check_postgres_adapter!
+
+    # This method is NOT safe to run more than once in a DDL transaction,
+    # as it could potentially lead to multiple tables being locked
+    # indefinitely
+    return block.call unless disable_ddl_transaction
+
     table = table.to_s
     quoted_table_name = connection.quote_table_name(table)
 

--- a/spec/pg_ha_migrations_spec.rb
+++ b/spec/pg_ha_migrations_spec.rb
@@ -31,6 +31,28 @@ RSpec.describe PgHaMigrations do
         end
       end
     end
+
+    context "disable_ddl_transactions" do
+      context "by default" do
+        it "is set to true" do
+          expect(PgHaMigrations.config.disable_ddl_transactions)
+            .to be(true)
+        end
+      end
+
+      context "overridden to be false" do
+        before(:each) do
+          PgHaMigrations.configure do |config|
+            config.disable_ddl_transactions = false
+          end
+        end
+
+        it "is set to false" do
+          expect(PgHaMigrations.config.disable_ddl_transactions)
+            .to be(false)
+        end
+      end
+    end
   end
 
   PgHaMigrations::AllowedVersions::ALLOWED_VERSIONS.each do |migration_klass|

--- a/spec/safe_migration_spec.rb
+++ b/spec/safe_migration_spec.rb
@@ -1278,5 +1278,52 @@ RSpec.describe PgHaMigrations::SafeStatements do
         end
       end
     end
+
+    describe "disable_ddl_transaction" do
+      context "when instance variable is unset" do
+        let(:migration) do
+          Class.new(migration_klass).new
+        end
+
+        context "when configured globally to be true" do
+          before(:each) do
+            allow(PgHaMigrations.config).to receive(:disable_ddl_transactions)
+              .and_return(true)
+          end
+
+          it "is true" do
+            expect(migration.disable_ddl_transaction).to be true
+          end
+        end
+
+        context "when configured globally to be false" do
+          before(:each) do
+            allow(PgHaMigrations.config).to receive(:disable_ddl_transactions)
+              .and_return(false)
+          end
+
+          it "is false" do
+            expect(migration.disable_ddl_transaction).to be false
+          end
+        end
+      end
+
+      context "when instance variable is set" do
+        let(:migration) do
+          Class.new(migration_klass) do
+            disable_ddl_transaction!
+          end.new
+        end
+
+        before(:each) do
+          allow(PgHaMigrations.config).to receive(:disable_ddl_transaction)
+            .and_return(false)
+        end
+
+        it "uses the instance variable value" do
+          expect(migration.disable_ddl_transaction).to be true
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
The gem, as currently implemented, disables all DDL transactions by default, for reducing the possibility of lock problems. We actually prefer to keep the DDL transactions to avoid situations where migrations are only half-applied, and instead encourage more smaller migrations through code review. This PR makes this behaviour opt-out. 

I've also refactored the `Config` into a proper class so it accepts keyword arguments, to avoid the situation we're getting into with `Config.new(true, false, true ... )` 