### PR TITLE
Out of band migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,20 @@ end
 Rake::Task["pg_ha_migrations:check_blocking_database_transactions"].enhance ["db:establish_connection"]
 ```
 
+## Out of band migrations
+
+Migrations that take a long time to run (e.g. creating indexes, dropping columns) can now be separated from the normal migration workflow by placing them in a different migrations directory and using `PgHaMigrations::OutOfBandMigrator`.
+
+`OutOfBandMigrator` offers an interactive prompt to run migrations. Given normal migrations in `db/migrate` and out of band migrations in `db/migrate_oob`, out of band migrations can be run as:
+
+```ruby
+oob_migrator = PgHaMigrations::OutOfBandMigrator.new(Rails.root.join("db/migrate_oob"))
+oob_migrator.run
+```
+
+### Things to note
+
+1. Migration versions should be in order and unique across all migration directories.
 
 ## Development
 

--- a/lib/pg_ha_migrations.rb
+++ b/lib/pg_ha_migrations.rb
@@ -46,6 +46,7 @@ require "pg_ha_migrations/allowed_versions"
 require "pg_ha_migrations/railtie"
 require "pg_ha_migrations/hacks/disable_ddl_transaction"
 require "pg_ha_migrations/unrun_migrations"
+require "pg_ha_migrations/out_of_band_migrator"
 
 module PgHaMigrations::AutoIncluder
   def inherited(klass)

--- a/lib/pg_ha_migrations.rb
+++ b/lib/pg_ha_migrations.rb
@@ -46,6 +46,7 @@ require "pg_ha_migrations/allowed_versions"
 require "pg_ha_migrations/railtie"
 require "pg_ha_migrations/hacks/disable_ddl_transaction"
 require "pg_ha_migrations/unrun_migrations"
+require "pg_ha_migrations/long_running_migrator"
 require "pg_ha_migrations/out_of_band_migrator"
 
 module PgHaMigrations::AutoIncluder

--- a/lib/pg_ha_migrations.rb
+++ b/lib/pg_ha_migrations.rb
@@ -45,6 +45,7 @@ require "pg_ha_migrations/dependent_objects_checks"
 require "pg_ha_migrations/allowed_versions"
 require "pg_ha_migrations/railtie"
 require "pg_ha_migrations/hacks/disable_ddl_transaction"
+require "pg_ha_migrations/unrun_migrations"
 
 module PgHaMigrations::AutoIncluder
   def inherited(klass)

--- a/lib/pg_ha_migrations.rb
+++ b/lib/pg_ha_migrations.rb
@@ -37,6 +37,7 @@ module PgHaMigrations
   UnsupportedAdapter = Class.new(Exception)
 end
 
+require "readline"
 require "pg_ha_migrations/blocking_database_transactions"
 require "pg_ha_migrations/blocking_database_transactions_reporter"
 require "pg_ha_migrations/unsafe_statements"

--- a/lib/pg_ha_migrations/long_running_migrator.rb
+++ b/lib/pg_ha_migrations/long_running_migrator.rb
@@ -1,0 +1,8 @@
+module PgHaMigrations
+  class LongRunningMigrator < ActiveRecord::Migrator
+    def ddl_transaction(_migration = nil, &block)
+      ActiveRecord::Base.connection.execute "set statement_timeout = 0"
+      block.call
+    end
+  end
+end

--- a/lib/pg_ha_migrations/out_of_band_migrator.rb
+++ b/lib/pg_ha_migrations/out_of_band_migrator.rb
@@ -1,8 +1,7 @@
 module PgHaMigrations
   class OutOfBandMigrator
-    def initialize(migration_files_path, stdin=STDIN, stdout=STDOUT)
+    def initialize(migration_files_path, stdout=STDOUT)
       @migration_files_path = migration_files_path
-      @stdin = stdin
       @stdout = stdout
     end
 
@@ -11,9 +10,7 @@ module PgHaMigrations
       _puts(blocking_database_transactions)
       _puts(instructions)
 
-      loop do
-        _prompt
-        command = _gets
+      while command = Readline.readline('> ', true)
         parsed_command = parse_command(command)
         if should_exit?(parsed_command[0])
           _puts("exiting...")
@@ -120,10 +117,6 @@ module PgHaMigrations
 
     def argument_error
       "Unknown command.\n\n" + instructions
-    end
-
-    def _gets
-      @stdin.gets
     end
 
     def _prompt

--- a/lib/pg_ha_migrations/out_of_band_migrator.rb
+++ b/lib/pg_ha_migrations/out_of_band_migrator.rb
@@ -78,7 +78,14 @@ module PgHaMigrations
     end
 
     def execute_command(command)
-      execute_print(command[1..-1])
+      cmd = command.shift
+      args = command
+      case cmd
+      when "print"
+        execute_print(args)
+      else
+        _puts argument_error
+      end
     end
 
     def execute_print(args)
@@ -90,7 +97,13 @@ module PgHaMigrations
         _puts blocking_database_transactions
       when "instructions"
         _puts instructions
+      else
+        _puts argument_error
       end
+    end
+
+    def argument_error
+      "Unknown command.\n\n" + instructions
     end
 
     def _gets

--- a/lib/pg_ha_migrations/out_of_band_migrator.rb
+++ b/lib/pg_ha_migrations/out_of_band_migrator.rb
@@ -1,7 +1,45 @@
 module PgHaMigrations
-  module OutOfBandMigrator
+  class OutOfBandMigrator
+    def initialize(suffix, stdin=STDIN, stdout=STDOUT)
+      @suffix = suffix
+      @stdin = stdin
+      @stdout = stdout
+    end
 
-    def self.instructions
+    def run
+      _puts(migrations_state)
+      _puts(blocking_database_transactions)
+      _puts(instructions)
+
+      loop do
+        _prompt
+        command = _gets
+        parsed_command = parse_command(command)
+        if should_exit?(parsed_command[0])
+          _puts("exiting...")
+          break
+        end
+
+        adjusted_command = parsed_command.reject{ |command| command =~ /version/i }
+        execute_command(adjusted_command)
+      end
+    end
+
+    def migrations_state
+      unrun_migrations = PgHaMigrations::UnrunMigrations.unrun_migrations(@suffix)
+      if unrun_migrations.any?
+        unrun_migrations_report = PgHaMigrations::UnrunMigrations.report(@suffix)
+      else
+        unrun_migrations_report = "No unrun out-of-band migrations."
+      end
+      """
+        ========================= Out Of Band Migrations To Be Run =========================
+        #{unrun_migrations_report.lines.map { |line| "\t#{line}" }.join(" ")}
+        ====================================================================================
+      """
+    end
+
+    def instructions
       """
         =================================== Instructions ===================================
         print blocking_database_transactions - Print blocking database transactions
@@ -13,8 +51,37 @@ module PgHaMigrations
       """
     end
 
-    def self.migrate_command
+    def blocking_database_transactions
+      """
+      """
+    end
+
+    def parse_command(command_string)
+      []
+    end
+
+    def migrate_command
       "migrate <version>                 - Run a migration, e.g. `migrate 24603`"
+    end
+
+    def should_exit?(command)
+      true
+    end
+
+    def execute_command(commad)
+
+    end
+
+    def _gets
+      @stdin.gets
+    end
+
+    def _prompt
+      @stdout.print "> "
+    end
+
+    def _puts(msg)
+      @stdout.puts msg
     end
   end
 end

--- a/lib/pg_ha_migrations/out_of_band_migrator.rb
+++ b/lib/pg_ha_migrations/out_of_band_migrator.rb
@@ -62,7 +62,11 @@ module PgHaMigrations
     end
 
     def parse_command(command_string)
-      []
+      if command_string.blank?
+        ["exit"]
+      else
+        command_string.split
+      end
     end
 
     def migrate_command
@@ -70,11 +74,23 @@ module PgHaMigrations
     end
 
     def should_exit?(command)
-      true
+      command == "exit"
     end
 
-    def execute_command(commad)
+    def execute_command(command)
+      execute_print(command[1..-1])
+    end
 
+    def execute_print(args)
+      print_command = args.shift
+      case print_command
+      when "migrations_state"
+        _puts migrations_state
+      when "blocking_database_transactions"
+        _puts blocking_database_transactions
+      when "instructions"
+        _puts instructions
+      end
     end
 
     def _gets

--- a/lib/pg_ha_migrations/out_of_band_migrator.rb
+++ b/lib/pg_ha_migrations/out_of_band_migrator.rb
@@ -1,0 +1,20 @@
+module PgHaMigrations
+  module OutOfBandMigrator
+
+    def self.instructions
+      """
+        =================================== Instructions ===================================
+        print blocking_database_transactions - Print blocking database transactions
+        print migrations_state               - Print all non-deployed migrations
+        print instructions                   - Print this message
+        #{migrate_command}
+        exit                                 - Exit the Out of Band Tactical Command Center
+        ====================================================================================
+      """
+    end
+
+    def self.migrate_command
+      "migrate <version>                 - Run a migration, e.g. `migrate 24603`"
+    end
+  end
+end

--- a/lib/pg_ha_migrations/out_of_band_migrator.rb
+++ b/lib/pg_ha_migrations/out_of_band_migrator.rb
@@ -52,7 +52,12 @@ module PgHaMigrations
     end
 
     def blocking_database_transactions
+      blocking_transactions = PgHaMigrations::BlockingDatabaseTransactionsReporter.get_blocking_transactions
+      report = PgHaMigrations::BlockingDatabaseTransactionsReporter.report(blocking_transactions)
       """
+        ========================== Blocking Database Transactions ==========================
+        #{report.lines.map{ |line| "\t#{line}" }.join(" ")}
+        ====================================================================================
       """
     end
 

--- a/lib/pg_ha_migrations/unrun_migrations.rb
+++ b/lib/pg_ha_migrations/unrun_migrations.rb
@@ -1,0 +1,36 @@
+module PgHaMigrations
+  module UnrunMigrations
+    def self.unrun_migrations(suffix)
+      _expected_migrations(suffix) - _actual_migrations(suffix)
+    end
+
+    def self._expected_migrations(suffix)
+      expected_migrations = []
+      _migration_files(suffix).each do |migration_file|
+        version = _migration_version(migration_file)
+
+        expected_migrations << {
+          :version => version,
+        }
+      end
+      expected_migrations
+    end
+
+    def self._actual_migrations(suffix)
+      actual_migrations = []
+      ActiveRecord::Base.connection.migration_context.get_all_versions.each do |version|
+        actual_migrations << {
+          :version => version.to_s
+        }
+      end
+      actual_migrations
+    end
+
+    def self._migration_version(migration_file)
+      migration_file.split("/").last.split("_").first
+    end
+
+    def self._migration_files(target, suffix)
+    end
+  end
+end

--- a/lib/pg_ha_migrations/unrun_migrations.rb
+++ b/lib/pg_ha_migrations/unrun_migrations.rb
@@ -36,7 +36,8 @@ module PgHaMigrations
       migration_file.split("/").last.split("_").first
     end
 
-    def self._migration_files(target, suffix)
+    def self._migration_files(suffix)
+      []
     end
   end
 end

--- a/lib/pg_ha_migrations/unrun_migrations.rb
+++ b/lib/pg_ha_migrations/unrun_migrations.rb
@@ -1,18 +1,18 @@
 module PgHaMigrations
   module UnrunMigrations
-    def self.report(suffix)
-      migrations = unrun_migrations(suffix)
+    def self.report(migration_files_path)
+      migrations = unrun_migrations(migration_files_path)
       "Unrun migrations:\n" +
         migrations.map { |migration| migration[:version] }.join("\n")
     end
 
-    def self.unrun_migrations(suffix)
-      _expected_migrations(suffix) - _actual_migrations(suffix)
+    def self.unrun_migrations(migration_files_path)
+      _expected_migrations(migration_files_path) - _actual_migrations(migration_files_path)
     end
 
-    def self._expected_migrations(suffix)
+    def self._expected_migrations(migration_files_path)
       expected_migrations = []
-      _migration_files(suffix).each do |migration_file|
+      _migration_files(migration_files_path).each do |migration_file|
         version = _migration_version(migration_file)
 
         expected_migrations << {
@@ -22,7 +22,7 @@ module PgHaMigrations
       expected_migrations
     end
 
-    def self._actual_migrations(suffix)
+    def self._actual_migrations(migration_files_path)
       actual_migrations = []
       ActiveRecord::Base.connection.migration_context.get_all_versions.each do |version|
         actual_migrations << {
@@ -36,8 +36,8 @@ module PgHaMigrations
       migration_file.split("/").last.split("_").first
     end
 
-    def self._migration_files(suffix)
-      []
+    def self._migration_files(migration_files_path)
+      Dir.glob("#{migration_files_path}/*")
     end
   end
 end

--- a/lib/pg_ha_migrations/unrun_migrations.rb
+++ b/lib/pg_ha_migrations/unrun_migrations.rb
@@ -1,5 +1,11 @@
 module PgHaMigrations
   module UnrunMigrations
+    def self.report(suffix)
+      migrations = unrun_migrations(suffix)
+      "Unrun migrations:\n" +
+        migrations.map { |migration| migration[:version] }.join("\n")
+    end
+
     def self.unrun_migrations(suffix)
       _expected_migrations(suffix) - _actual_migrations(suffix)
     end

--- a/lib/tasks/blocking_transactions.rake
+++ b/lib/tasks/blocking_transactions.rake
@@ -5,5 +5,12 @@ namespace :pg_ha_migrations do
   task :check_blocking_database_transactions do
     PgHaMigrations::BlockingDatabaseTransactionsReporter.run
   end
+
+  desc "runs out of band migrations"
+  task :migrate_out_of_band => :load_db_environment do
+    PgHaMigrations::OutOfBandMigrator.run
+  end
+
+  task :migrate_oob => :migrate_out_of_band
 end
 

--- a/lib/tasks/blocking_transactions.rake
+++ b/lib/tasks/blocking_transactions.rake
@@ -5,12 +5,5 @@ namespace :pg_ha_migrations do
   task :check_blocking_database_transactions do
     PgHaMigrations::BlockingDatabaseTransactionsReporter.run
   end
-
-  desc "runs out of band migrations"
-  task :migrate_out_of_band => :load_db_environment do
-    PgHaMigrations::OutOfBandMigrator.run
-  end
-
-  task :migrate_oob => :migrate_out_of_band
 end
 

--- a/spec/data/migrations/924201_migrate_9242_01.rb
+++ b/spec/data/migrations/924201_migrate_9242_01.rb
@@ -1,0 +1,12 @@
+class Migrate924201 < ActiveRecord::Migration::Current
+  def up
+    safe_create_table :bar1 do |t|
+      t.timestamps :null => false
+      t.text :text_column
+    end
+    safe_create_table :bar2 do |t|
+      t.timestamps :null => false
+      t.text :text_column
+    end
+  end
+end

--- a/spec/out_of_band_migrator_spec.rb
+++ b/spec/out_of_band_migrator_spec.rb
@@ -1,13 +1,82 @@
 require "spec_helper"
 
 RSpec.describe PgHaMigrations::OutOfBandMigrator do
-  describe "self.instructions" do
+  describe "run" do
+    it "prints instructions and waits for prompt" do
+      stdin = StringIO.new
+      stdout = StringIO.new
+      stdin.puts "exit"
+      stdin.rewind
+      migrator = PgHaMigrations::OutOfBandMigrator.new("_oob", stdin, stdout)
+      migrator.run
+
+      expect(stdout.string).to match(/migrations_state/)
+      expect(stdout.string).to match(/blocking_database_transactions/)
+      expect(stdout.string).to match(/migrate/)
+      expect(stdout.string).to match(/exit/)
+    end
+
+    it "prints the migrations state" do
+      migration = Class.new(ActiveRecord::Migration::Current) do
+        def up
+          safe_create_table :foos1 do |t|
+            t.timestamps :null => false
+            t.text :text_column
+          end
+          safe_create_table :foos2 do |t|
+            t.timestamps :null => false
+            t.text :text_column
+          end
+        end
+      end
+
+      migration.version = 24000
+      migration.name = "240_00"
+
+      migration.suppress_messages do
+        ActiveRecord::Migrator.new(:up, [migration]).migrate
+      end
+
+      allow(PgHaMigrations::UnrunMigrations).to receive(:_migration_files).with("_oob").and_return(
+        [
+          "db/migrate_oob/924201_release_9242_01.rb",
+          "db/migrate_oob/924202_release_9242_01.rb",
+          "db/migrate_oob/924203_release_9242_01.rb",
+          "db/migrate_oob/924204_release_9242_01.rb",
+          "db/migrate_oob/24000_release_240_00.rb",
+        ]
+      )
+
+      stdin = StringIO.new
+      stdout = StringIO.new
+      stdin.puts "migrations_state"
+      stdin.puts "exit"
+      stdin.rewind
+      migrator = PgHaMigrations::OutOfBandMigrator.new("_oob", stdin, stdout)
+      migrator.run
+
+      expect(stdout.string).to match(/Out Of Band Migrations To Be Run/)
+      expect(stdout.string).to match(/Unrun migrations:/)
+      expect(stdout.string).to match(/924201/)
+      expect(stdout.string).to match(/924202/)
+      expect(stdout.string).to match(/924203/)
+      expect(stdout.string).to match(/924204/)
+    end
+  end
+
+  describe "instructions" do
     it "has instructions" do
-      instructions = PgHaMigrations::OutOfBandMigrator.instructions
+      migrator = PgHaMigrations::OutOfBandMigrator.new("_oob")
+      instructions = migrator.instructions
       expect(instructions).to match(/migrations_state/)
       expect(instructions).to match(/blocking_database_transactions/)
       expect(instructions).to match(/migrate/)
       expect(instructions).to match(/exit/)
+    end
+  end
+
+  describe "migrations state" do
+    it "includes the migration report" do
     end
   end
 end

--- a/spec/out_of_band_migrator_spec.rb
+++ b/spec/out_of_band_migrator_spec.rb
@@ -5,11 +5,9 @@ RSpec.describe PgHaMigrations::OutOfBandMigrator do
 
   describe "run" do
     it "prints instructions and waits for prompt" do
-      stdin = StringIO.new
       stdout = StringIO.new
-      stdin.puts "exit"
-      stdin.rewind
-      migrator = PgHaMigrations::OutOfBandMigrator.new(migrations_path, stdin, stdout)
+      allow(Readline).to receive(:readline).with('> ', true).and_return("exit", nil)
+      migrator = PgHaMigrations::OutOfBandMigrator.new(migrations_path, stdout)
       migrator.run
 
       expect(stdout.string).to match(/migrations_state/)
@@ -19,12 +17,9 @@ RSpec.describe PgHaMigrations::OutOfBandMigrator do
     end
 
     it "responds to instructions command" do
-      stdin = StringIO.new
       stdout = StringIO.new
-      stdin.puts "print instructions"
-      stdin.puts "exit"
-      stdin.rewind
-      migrator = PgHaMigrations::OutOfBandMigrator.new(migrations_path, stdin, stdout)
+      allow(Readline).to receive(:readline).with('> ', true).and_return("print instructions", "exit", nil)
+      migrator = PgHaMigrations::OutOfBandMigrator.new(migrations_path, stdout)
       migrator.run
 
       expect(stdout.string.scan(/print migrations_state/).size).to eq(2)
@@ -36,11 +31,9 @@ RSpec.describe PgHaMigrations::OutOfBandMigrator do
     it "always prints the migrations state" do
       run_migration
 
-      stdin = StringIO.new
       stdout = StringIO.new
-      stdin.puts "exit"
-      stdin.rewind
-      migrator = PgHaMigrations::OutOfBandMigrator.new(migrations_path, stdin, stdout)
+      allow(Readline).to receive(:readline).with('> ', true).and_return("exit", nil)
+      migrator = PgHaMigrations::OutOfBandMigrator.new(migrations_path, stdout)
       migrator.run
 
       expect(stdout.string).to match(/Out Of Band Migrations To Be Run/)
@@ -51,12 +44,9 @@ RSpec.describe PgHaMigrations::OutOfBandMigrator do
     it "responds to migrations_state command" do
       run_migration
 
-      stdin = StringIO.new
       stdout = StringIO.new
-      stdin.puts "print migrations_state"
-      stdin.puts "exit"
-      stdin.rewind
-      migrator = PgHaMigrations::OutOfBandMigrator.new(migrations_path, stdin, stdout)
+      allow(Readline).to receive(:readline).with('> ', true).and_return("print migrations_state", "exit", nil)
+      migrator = PgHaMigrations::OutOfBandMigrator.new(migrations_path, stdout)
       migrator.run
 
       expect(stdout.string.scan(/Out Of Band Migrations To Be Run/).size).to eq(2)
@@ -77,11 +67,9 @@ RSpec.describe PgHaMigrations::OutOfBandMigrator do
       allow(PgHaMigrations::BlockingDatabaseTransactionsReporter).to receive(:get_blocking_transactions).and_return(blocking_transactions)
       allow(PgHaMigrations::BlockingDatabaseTransactionsReporter).to receive(:report).with(blocking_transactions).and_return(report)
 
-      stdin = StringIO.new
       stdout = StringIO.new
-      stdin.puts "exit"
-      stdin.rewind
-      migrator = PgHaMigrations::OutOfBandMigrator.new(migrations_path, stdin, stdout)
+      allow(Readline).to receive(:readline).with('> ', true).and_return("exit", nil)
+      migrator = PgHaMigrations::OutOfBandMigrator.new(migrations_path, stdout)
       migrator.run
 
       expect(stdout.string).to match(/Potentially blocking database transactions/)
@@ -104,12 +92,9 @@ RSpec.describe PgHaMigrations::OutOfBandMigrator do
       allow(PgHaMigrations::BlockingDatabaseTransactionsReporter).to receive(:get_blocking_transactions).and_return(blocking_transactions)
       allow(PgHaMigrations::BlockingDatabaseTransactionsReporter).to receive(:report).with(blocking_transactions).and_return(report)
 
-      stdin = StringIO.new
       stdout = StringIO.new
-      stdin.puts "print blocking_database_transactions"
-      stdin.puts "exit"
-      stdin.rewind
-      migrator = PgHaMigrations::OutOfBandMigrator.new(migrations_path, stdin, stdout)
+      allow(Readline).to receive(:readline).with('> ', true).and_return("print blocking_database_transactions", "exit", nil)
+      migrator = PgHaMigrations::OutOfBandMigrator.new(migrations_path, stdout)
       migrator.run
 
       expect(stdout.string.scan(/Potentially blocking database transactions/).size).to eq(2)
@@ -120,24 +105,18 @@ RSpec.describe PgHaMigrations::OutOfBandMigrator do
     end
 
     it "displays error for unknown print command" do
-      stdin = StringIO.new
       stdout = StringIO.new
-      stdin.puts "print foo"
-      stdin.puts "exit"
-      stdin.rewind
-      migrator = PgHaMigrations::OutOfBandMigrator.new(migrations_path, stdin, stdout)
+      allow(Readline).to receive(:readline).with('> ', true).and_return("print foo", "exit", nil)
+      migrator = PgHaMigrations::OutOfBandMigrator.new(migrations_path, stdout)
       migrator.run
 
       expect(stdout.string).to match(/Unknown command./)
     end
 
     it "displays error for unknown top level command" do
-      stdin = StringIO.new
       stdout = StringIO.new
-      stdin.puts "dosomething"
-      stdin.puts "exit"
-      stdin.rewind
-      migrator = PgHaMigrations::OutOfBandMigrator.new(migrations_path, stdin, stdout)
+      allow(Readline).to receive(:readline).with('> ', true).and_return("dosomething", "exit", nil)
+      migrator = PgHaMigrations::OutOfBandMigrator.new(migrations_path, stdout)
       migrator.run
 
       expect(stdout.string).to match(/Unknown command./)
@@ -147,12 +126,9 @@ RSpec.describe PgHaMigrations::OutOfBandMigrator do
       run_migration
       migrations_path = File.absolute_path("spec/data/migrations")
 
-      stdin = StringIO.new
       stdout = StringIO.new
-      stdin.puts "migrate 924201"
-      stdin.puts "exit"
-      stdin.rewind
-      migrator = PgHaMigrations::OutOfBandMigrator.new(migrations_path, stdin, stdout)
+      allow(Readline).to receive(:readline).with('> ', true).and_return("migrate 924201", "exit", nil)
+      migrator = PgHaMigrations::OutOfBandMigrator.new(migrations_path, stdout)
       migrator.run
 
       migration_context = ActiveRecord::MigrationContext.new migrations_path
@@ -164,12 +140,9 @@ RSpec.describe PgHaMigrations::OutOfBandMigrator do
       run_migration
       migrations_path = File.absolute_path("spec/data/migrations")
 
-      stdin = StringIO.new
       stdout = StringIO.new
-      stdin.puts "migrate 99999"
-      stdin.puts "exit"
-      stdin.rewind
-      migrator = PgHaMigrations::OutOfBandMigrator.new(migrations_path, stdin, stdout)
+      allow(Readline).to receive(:readline).with('> ', true).and_return("migrate 99999", "exit", nil)
+      migrator = PgHaMigrations::OutOfBandMigrator.new(migrations_path, stdout)
       migrator.run
 
       expect(stdout.string).to match(/Migration 99999 does not exist in #{migrations_path}./)

--- a/spec/out_of_band_migrator_spec.rb
+++ b/spec/out_of_band_migrator_spec.rb
@@ -142,6 +142,30 @@ RSpec.describe PgHaMigrations::OutOfBandMigrator do
       expect(stdout.string.scan(/Transaction 3/).size).to eq(2)
       expect(stdout.string.scan(/Transaction 4/).size).to eq(2)
     end
+
+    it "displays error for unknown print command" do
+      stdin = StringIO.new
+      stdout = StringIO.new
+      stdin.puts "print foo"
+      stdin.puts "exit"
+      stdin.rewind
+      migrator = PgHaMigrations::OutOfBandMigrator.new("_oob", stdin, stdout)
+      migrator.run
+
+      expect(stdout.string).to match(/Unknown command./)
+    end
+
+    it "displays error for unknown top level command" do
+      stdin = StringIO.new
+      stdout = StringIO.new
+      stdin.puts "dosomething"
+      stdin.puts "exit"
+      stdin.rewind
+      migrator = PgHaMigrations::OutOfBandMigrator.new("_oob", stdin, stdout)
+      migrator.run
+
+      expect(stdout.string).to match(/Unknown command./)
+    end
   end
 
   describe "instructions" do

--- a/spec/out_of_band_migrator_spec.rb
+++ b/spec/out_of_band_migrator_spec.rb
@@ -12,8 +12,23 @@ RSpec.describe PgHaMigrations::OutOfBandMigrator do
 
       expect(stdout.string).to match(/migrations_state/)
       expect(stdout.string).to match(/blocking_database_transactions/)
-      expect(stdout.string).to match(/migrate/)
+      expect(stdout.string).to match(/migrate /)
       expect(stdout.string).to match(/exit/)
+    end
+
+    it "responds to instructions command" do
+      stdin = StringIO.new
+      stdout = StringIO.new
+      stdin.puts "print instructions"
+      stdin.puts "exit"
+      stdin.rewind
+      migrator = PgHaMigrations::OutOfBandMigrator.new("_oob", stdin, stdout)
+      migrator.run
+
+      expect(stdout.string.scan(/print migrations_state/).size).to eq(2)
+      expect(stdout.string.scan(/print instructions/).size).to eq(2)
+      expect(stdout.string.scan(/print blocking_database_transactions/).size).to eq(2)
+      expect(stdout.string.scan(/exit /).size).to eq(2)
     end
 
     it "always prints the migrations state" do
@@ -44,6 +59,35 @@ RSpec.describe PgHaMigrations::OutOfBandMigrator do
       expect(stdout.string).to match(/924204/)
     end
 
+    it "responds to migrations_state command" do
+      run_migration
+
+      allow(PgHaMigrations::UnrunMigrations).to receive(:_migration_files).with("_oob").and_return(
+        [
+          "db/migrate_oob/924201_release_9242_01.rb",
+          "db/migrate_oob/924202_release_9242_01.rb",
+          "db/migrate_oob/924203_release_9242_01.rb",
+          "db/migrate_oob/924204_release_9242_01.rb",
+          "db/migrate_oob/24000_release_240_00.rb",
+        ]
+      )
+
+      stdin = StringIO.new
+      stdout = StringIO.new
+      stdin.puts "print migrations_state"
+      stdin.puts "exit"
+      stdin.rewind
+      migrator = PgHaMigrations::OutOfBandMigrator.new("_oob", stdin, stdout)
+      migrator.run
+
+      expect(stdout.string.scan(/Out Of Band Migrations To Be Run/).size).to eq(2)
+      expect(stdout.string.scan(/Unrun migrations:/).size).to eq(2)
+      expect(stdout.string.scan(/924201/).size).to eq(2)
+      expect(stdout.string.scan(/924202/).size).to eq(2)
+      expect(stdout.string.scan(/924203/).size).to eq(2)
+      expect(stdout.string.scan(/924204/).size).to eq(2)
+    end
+
     it "always prints blocking db transactions" do
       report = """
        Potentially blocking database transactions:
@@ -70,6 +114,34 @@ RSpec.describe PgHaMigrations::OutOfBandMigrator do
       expect(stdout.string).to match(/Transaction 3/)
       expect(stdout.string).to match(/Transaction 4/)
     end
+
+    it "responds to blocking_database_transactions" do
+      report = """
+       Potentially blocking database transactions:
+       Transaction 1
+       Transaction 2
+       Transaction 3
+       Transaction 4
+      """
+
+      blocking_transactions = [1, 2, 3, 4]
+      allow(PgHaMigrations::BlockingDatabaseTransactionsReporter).to receive(:get_blocking_transactions).and_return(blocking_transactions)
+      allow(PgHaMigrations::BlockingDatabaseTransactionsReporter).to receive(:report).with(blocking_transactions).and_return(report)
+
+      stdin = StringIO.new
+      stdout = StringIO.new
+      stdin.puts "print blocking_database_transactions"
+      stdin.puts "exit"
+      stdin.rewind
+      migrator = PgHaMigrations::OutOfBandMigrator.new("_oob", stdin, stdout)
+      migrator.run
+
+      expect(stdout.string.scan(/Potentially blocking database transactions/).size).to eq(2)
+      expect(stdout.string.scan(/Transaction 1/).size).to eq(2)
+      expect(stdout.string.scan(/Transaction 2/).size).to eq(2)
+      expect(stdout.string.scan(/Transaction 3/).size).to eq(2)
+      expect(stdout.string.scan(/Transaction 4/).size).to eq(2)
+    end
   end
 
   describe "instructions" do
@@ -85,6 +157,32 @@ RSpec.describe PgHaMigrations::OutOfBandMigrator do
 
   describe "migrations state" do
     it "includes the migration report" do
+    end
+  end
+
+  describe "parse_command" do
+    it "defaults to exit" do
+      migrator = PgHaMigrations::OutOfBandMigrator.new("_oob")
+      parsed = migrator.parse_command(nil)
+      expect(parsed).to eq(["exit"])
+    end
+
+    it "splits commands" do
+      migrator = PgHaMigrations::OutOfBandMigrator.new("_oob")
+      parsed = migrator.parse_command("print blocking_database_transactions")
+      expect(parsed).to eq(["print", "blocking_database_transactions"])
+    end
+  end
+
+  describe "should_exit?" do
+    it "is truthy for 'exit'" do
+      migrator = PgHaMigrations::OutOfBandMigrator.new("_oob")
+      expect(migrator.should_exit?("exit")).to be_truthy
+    end
+
+    it "is falsey for everything else" do
+      migrator = PgHaMigrations::OutOfBandMigrator.new("_oob")
+      expect(migrator.should_exit?("print foo")).to be_falsey
     end
   end
 

--- a/spec/out_of_band_migrator_spec.rb
+++ b/spec/out_of_band_migrator_spec.rb
@@ -1,0 +1,13 @@
+require "spec_helper"
+
+RSpec.describe PgHaMigrations::OutOfBandMigrator do
+  describe "self.instructions" do
+    it "has instructions" do
+      instructions = PgHaMigrations::OutOfBandMigrator.instructions
+      expect(instructions).to match(/migrations_state/)
+      expect(instructions).to match(/blocking_database_transactions/)
+      expect(instructions).to match(/migrate/)
+      expect(instructions).to match(/exit/)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require "bundler/setup"
 require "pg_ha_migrations"
 require "db-query-matchers"
+require "pry"
 
 puts "rspec config"
 RSpec.configure do |config|

--- a/spec/unrun_migrations_spec.rb
+++ b/spec/unrun_migrations_spec.rb
@@ -1,0 +1,45 @@
+require "spec_helper"
+
+RSpec.describe PgHaMigrations::UnrunMigrations do
+  describe "self.unrun_migrations", :test_isolation_strategy => :truncation do
+    it "returns migrations that have not been run against the database" do
+      migration = Class.new(ActiveRecord::Migration::Current) do
+        def name
+          "240_00"
+        end
+        def version
+          123
+        end
+        def up
+          safe_create_table :foos1 do |t|
+            t.timestamps :null => false
+            t.text :text_column
+          end
+          safe_create_table :foos2 do |t|
+            t.timestamps :null => false
+            t.text :text_column
+          end
+        end
+      end
+
+      migration.version = 24000
+      migration.name = "240_00"
+
+      migration.suppress_messages do
+        ActiveRecord::Migrator.new(:up, [migration]).migrate
+      end
+
+      expect(PgHaMigrations::UnrunMigrations).to receive(:_migration_files).with("_oob").and_return(
+        [
+          "db/migrate_oob/924201_release_9242_01.rb",
+          "db/migrate_oob/24000_release_240_00.rb",
+        ]
+      )
+
+      unrun_migrations = PgHaMigrations::UnrunMigrations.unrun_migrations("_oob")
+
+      expect(unrun_migrations).to include({:version => "924201"})
+      expect(unrun_migrations).to_not include({:version => "24000"})
+    end
+  end
+end

--- a/spec/unrun_migrations_spec.rb
+++ b/spec/unrun_migrations_spec.rb
@@ -4,12 +4,6 @@ RSpec.describe PgHaMigrations::UnrunMigrations do
   describe "self.unrun_migrations", :test_isolation_strategy => :truncation do
     it "returns migrations that have not been run against the database" do
       migration = Class.new(ActiveRecord::Migration::Current) do
-        def name
-          "240_00"
-        end
-        def version
-          123
-        end
         def up
           safe_create_table :foos1 do |t|
             t.timestamps :null => false
@@ -40,6 +34,74 @@ RSpec.describe PgHaMigrations::UnrunMigrations do
 
       expect(unrun_migrations).to include({:version => "924201"})
       expect(unrun_migrations).to_not include({:version => "24000"})
+    end
+
+    it "informs that there are no unrun migrations when none exist" do
+      migration = Class.new(ActiveRecord::Migration::Current) do
+        def up
+          safe_create_table :foos1 do |t|
+            t.timestamps :null => false
+            t.text :text_column
+          end
+          safe_create_table :foos2 do |t|
+            t.timestamps :null => false
+            t.text :text_column
+          end
+        end
+      end
+
+      migration.version = 24000
+      migration.name = "240_00"
+
+      migration.suppress_messages do
+        ActiveRecord::Migrator.new(:up, [migration]).migrate
+      end
+
+      expect(PgHaMigrations::UnrunMigrations).to receive(:_migration_files).with("_oob").and_return(
+        [
+          "db/migrate_oob/24000_release_240_00.rb",
+        ]
+      )
+
+      migrations = PgHaMigrations::UnrunMigrations.unrun_migrations("_oob")
+      expect(migrations).to be_empty
+    end
+  end
+
+  describe "self.report" do
+    it "returns migrations that have not been run against the database" do
+      migration = Class.new(ActiveRecord::Migration::Current) do
+        def up
+          safe_create_table :foos1 do |t|
+            t.timestamps :null => false
+            t.text :text_column
+          end
+          safe_create_table :foos2 do |t|
+            t.timestamps :null => false
+            t.text :text_column
+          end
+        end
+      end
+
+      migration.version = 24000
+      migration.name = "240_00"
+
+      migration.suppress_messages do
+        ActiveRecord::Migrator.new(:up, [migration]).migrate
+      end
+
+      expect(PgHaMigrations::UnrunMigrations).to receive(:_migration_files).with("_oob").and_return(
+        [
+          "db/migrate_oob/924201_release_9242_01.rb",
+          "db/migrate_oob/924202_release_9242_01.rb",
+          "db/migrate_oob/924203_release_9242_01.rb",
+          "db/migrate_oob/924204_release_9242_01.rb",
+          "db/migrate_oob/24000_release_240_00.rb",
+        ]
+      )
+
+      report = PgHaMigrations::UnrunMigrations.report("_oob")
+      expect(report).to eq("Unrun migrations:\n924201\n924202\n924203\n924204")
     end
   end
 end


### PR DESCRIPTION
### What?

- This PR adds support for Out of Band migrations. 

### Why?

- We want to make our out of band migration utilities available to other codebases.

