### PR TITLE
Delete bundler 2.x and use 1.x instead.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,6 @@ services:
   - postgresql
 addons:
   postgresql: "9.6"
-before_install: gem install bundler -v 1.15.4
+before_install:
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler -v 1.15.4


### PR DESCRIPTION
### What?

- This PR changes our Travis CI pre build steps to explicitly install bundler 1.x

### Why?

- Travis CI changed the default Bundler version to 2.x and this is the [recommended](https://docs.travis-ci.com/user/languages/ruby/#bundler-20) approach to continue using 1.x

Signed-off-by: Sadique Ali Koothumadan <sadiqueali.koothumadan@getbraintree.com>