### PR TITLE
Disallow `force: true` when creating table

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ While `unsafe_*` methods were historically (through 1.0) pure wrappers for invok
 
 When `unsafe_*` migration methods support checks of this type you can bypass the checks by passing an `:allow_dependent_objects` key in the method's `options` hash containing an array of dependent object types you'd like to allow. Until 2.0 none of these checks will run by default, but you can opt-in by setting `config.check_for_dependent_objects = true` [in your configuration initializer](#configuration).
 
+Similarly we believe the `force: true` option to ActiveRecord's `create_table` method is always unsafe, and therefore we disallow it even when calling `unsafe_create_table`. This option won't be enabled by default until 2.0, but you can opt-in by setting `config.allow_force_create_table = false` [in your configuration initializer](#configuration).
+
 [Running multiple DDL statements inside a transaction acquires exclusive locks on all of the modified objects](https://medium.com/braintree-product-technology/postgresql-at-scale-database-schema-changes-without-downtime-20d3749ed680#cc22). For that reason, this gem [disables DDL transactions](./lib/pg_ha_migrations.rb:8) by default. You can change this by resetting `ActiveRecord::Migration.disable_ddl_transaction` in your application.
 
 The following functionality is currently unsupported:

--- a/lib/pg_ha_migrations.rb
+++ b/lib/pg_ha_migrations.rb
@@ -7,13 +7,15 @@ require "relation_to_struct"
 module PgHaMigrations
   Config = Struct.new(
     :disable_default_migration_methods,
-    :check_for_dependent_objects
+    :check_for_dependent_objects,
+    :allow_force_create_table
   )
 
   def self.config
     @config ||= Config.new(
       true,
-      false
+      false,
+      true
     )
   end
 

--- a/lib/pg_ha_migrations/safe_statements.rb
+++ b/lib/pg_ha_migrations/safe_statements.rb
@@ -1,5 +1,9 @@
 module PgHaMigrations::SafeStatements
   def safe_create_table(table, options={}, &block)
+    if options[:force]
+      raise PgHaMigrations::UnsafeMigrationError.new(":force is NOT SAFE! Explicitly call unsafe_drop_table first if you want to recreate an existing table")
+    end
+
     unsafe_create_table(table, options, &block)
   end
 

--- a/spec/pg_ha_migrations_spec.rb
+++ b/spec/pg_ha_migrations_spec.rb
@@ -41,6 +41,20 @@ RSpec.describe PgHaMigrations do
         expect(PgHaMigrations.config.check_for_dependent_objects).to be(true)
       end
     end
+
+    context "allow_force_create_table" do
+      it "is set to true by default" do
+        expect(PgHaMigrations.config.allow_force_create_table).to be(true)
+      end
+
+      it "can be overriden to false" do
+        PgHaMigrations.configure do |config|
+          config.allow_force_create_table = false
+        end
+
+        expect(PgHaMigrations.config.allow_force_create_table).to be(false)
+      end
+    end
   end
 
   PgHaMigrations::AllowedVersions::ALLOWED_VERSIONS.each do |migration_klass|


### PR DESCRIPTION
The `force: true` option to `ActiveRecord::Migration#create_table`
causes the table to be dropped if it already exists. This is unsafe by
definition, and should instead require an explicit `drop_table` instead
-- even when calling the `unsafe_create_table` variant.

We always disallow the option to `safe_create_table`, but to ensure we
don't break backwards compatibility for `unsafe_create_table`, I've
configured the default for this new feature to continue to allow the
old behavior -- making it opt-in for now, but with the expectation that
we'll flip the default in the next major version.