### PR TITLE
Disallow `def change` in migrations.

### DIFF
--- a/lib/pg_ha_migrations.rb
+++ b/lib/pg_ha_migrations.rb
@@ -35,6 +35,10 @@ module PgHaMigrations
   # as expected or get the schema into an inconsistent state
   InvalidMigrationError = Class.new(Exception)
 
+  # Unsupported migrations use ActiveRecord::Migration features that
+  # we don't support, and therefore will likely have unexpected behavior.
+  UnsupportedMigrationError = Class.new(Exception)
+
   # This gem only supports the PostgreSQL adapter at this time.
   UnsupportedAdapter = Class.new(Exception)
 end

--- a/lib/pg_ha_migrations/safe_statements.rb
+++ b/lib/pg_ha_migrations/safe_statements.rb
@@ -98,6 +98,14 @@ module PgHaMigrations::SafeStatements
     raise PgHaMigrations::UnsupportedAdapter, "This gem only works with the #{expected_adapter} adapter, found #{actual_adapter} instead" unless actual_adapter == expected_adapter
   end
 
+  def migrate(direction)
+    if respond_to?(:change)
+      raise PgHaMigrations::UnsupportedMigrationError, "Tracking changes for automated rollback is not supported; use explicit #up instead."
+    end
+
+    super(direction)
+  end
+
   def exec_migration(conn, direction)
     _check_postgres_adapter!
     super(conn, direction)

--- a/spec/pg_ha_migrations_spec.rb
+++ b/spec/pg_ha_migrations_spec.rb
@@ -58,6 +58,24 @@ RSpec.describe PgHaMigrations do
   end
 
   PgHaMigrations::AllowedVersions::ALLOWED_VERSIONS.each do |migration_klass|
+    describe "general tests for #{migration_klass.name}" do
+      it "disallows using the #change method on migrations" do
+        subclass = Class.new(migration_klass) do
+          def change
+            # Do nothing.
+          end
+        end
+
+        expect do
+          subclass.migrate(:up)
+        end.to raise_error(PgHaMigrations::UnsupportedMigrationError)
+
+        expect do
+          subclass.migrate(:down)
+        end.to raise_error(PgHaMigrations::UnsupportedMigrationError)
+      end
+    end
+
     describe "interaction with ActiveRecord::Migration::Compatibility inheritance hierarchy with #{migration_klass.name}" do
       let(:subclass) { Class.new(migration_klass) }
 


### PR DESCRIPTION
We already explicitly say in the README to "never use `def change`". But
since we never rollback, we'd missed actually disallowing that feature.

So, since it's effectively guaranteed to result in unexpected behavior
(since we don't support rollback), actually disallow `def change` up
front.

Fixes #3.