### PR TITLE
Allow add_column with default at PG 11

### DIFF
--- a/lib/pg_ha_migrations/safe_statements.rb
+++ b/lib/pg_ha_migrations/safe_statements.rb
@@ -26,11 +26,13 @@ module PgHaMigrations::SafeStatements
   end
 
   def safe_add_column(table, column, type, options = {})
-    if options.has_key? :default
-      raise PgHaMigrations::UnsafeMigrationError.new(":default is NOT SAFE! Use safe_change_column_default afterwards then backfill the data to prevent locking the table")
-    end
-    if options[:null] == false
-      raise PgHaMigrations::UnsafeMigrationError.new(":null => false is NOT SAFE if the table has data! If you _really_ want to do this, use unsafe_make_column_not_nullable")
+    unless ActiveRecord::Base.connection.postgresql_version >= 110000
+      if options.has_key? :default
+        raise PgHaMigrations::UnsafeMigrationError.new(":default is NOT SAFE! Use safe_change_column_default afterwards then backfill the data to prevent locking the table")
+      end
+      if options[:null] == false
+        raise PgHaMigrations::UnsafeMigrationError.new(":null => false is NOT SAFE if the table has data! If you _really_ want to do this, use unsafe_make_column_not_nullable")
+      end
     end
 
     unsafe_add_column(table, column, type, options)

--- a/lib/pg_ha_migrations/safe_statements.rb
+++ b/lib/pg_ha_migrations/safe_statements.rb
@@ -26,7 +26,8 @@ module PgHaMigrations::SafeStatements
   end
 
   def safe_add_column(table, column, type, options = {})
-    unless ActiveRecord::Base.connection.postgresql_version >= 110000
+    puts ActiveRecord::Base.connection.postgresql_version
+    unless ActiveRecord::Base.connection.postgresql_version >= 11_00_00
       if options.has_key? :default
         raise PgHaMigrations::UnsafeMigrationError.new(":default is NOT SAFE! Use safe_change_column_default afterwards then backfill the data to prevent locking the table")
       end

--- a/lib/pg_ha_migrations/safe_statements.rb
+++ b/lib/pg_ha_migrations/safe_statements.rb
@@ -26,7 +26,6 @@ module PgHaMigrations::SafeStatements
   end
 
   def safe_add_column(table, column, type, options = {})
-    puts ActiveRecord::Base.connection.postgresql_version
     unless ActiveRecord::Base.connection.postgresql_version >= 11_00_00
       if options.has_key? :default
         raise PgHaMigrations::UnsafeMigrationError.new(":default is NOT SAFE! Use safe_change_column_default afterwards then backfill the data to prevent locking the table")

--- a/lib/pg_ha_migrations/safe_statements.rb
+++ b/lib/pg_ha_migrations/safe_statements.rb
@@ -26,6 +26,10 @@ module PgHaMigrations::SafeStatements
   end
 
   def safe_add_column(table, column, type, options = {})
+    if options.has_key?(:default) && options[:default].include?("(")
+      raise PgHaMigrations::UnsafeMigrationError.new(":default is NOT SAFE! Use safe_change_column_default afterwards then backfill the data to prevent locking the table")
+    end
+
     unless ActiveRecord::Base.connection.postgresql_version >= 11_00_00
       if options.has_key? :default
         raise PgHaMigrations::UnsafeMigrationError.new(":default is NOT SAFE! Use safe_change_column_default afterwards then backfill the data to prevent locking the table")

--- a/lib/pg_ha_migrations/safe_statements.rb
+++ b/lib/pg_ha_migrations/safe_statements.rb
@@ -31,7 +31,7 @@ module PgHaMigrations::SafeStatements
     end
 
     unless ActiveRecord::Base.connection.postgresql_version >= 11_00_00
-      if options.has_key? :default
+      if options.has_key?(:default)
         raise PgHaMigrations::UnsafeMigrationError.new(":default is NOT SAFE! Use safe_change_column_default afterwards then backfill the data to prevent locking the table")
       end
       if options[:null] == false

--- a/spec/safe_statements_spec.rb
+++ b/spec/safe_statements_spec.rb
@@ -512,7 +512,7 @@ RSpec.describe PgHaMigrations::SafeStatements do
         end
 
         describe "safe_add_column" do
-          it "add column without a default" do
+          it "adds column without a default" do
             migration = Class.new(migration_klass) do
               def up
                 unsafe_create_table :foos

--- a/spec/safe_statements_spec.rb
+++ b/spec/safe_statements_spec.rb
@@ -931,7 +931,7 @@ RSpec.describe PgHaMigrations::SafeStatements do
           end
 
           it "raises if connecting to Postgres 9.1 databases" do
-            allow(ActiveRecord::Base.connection).to receive(:postgresql_version).and_return(9_01_12)
+            allow(ActiveRecord::Base.connection).to receive(:postgresql_version).and_return(90112)
 
             test_migration = Class.new(migration_klass) do
               def up
@@ -1002,7 +1002,7 @@ RSpec.describe PgHaMigrations::SafeStatements do
           let(:migration) { Class.new(migration_klass).new }
 
           before(:each) do
-            skip "Only relevant on Postgres 9.3+" unless ActiveRecord::Base.connection.postgresql_version >= 9_03_00
+            skip "Only relevant on Postgres 9.3+" unless ActiveRecord::Base.connection.postgresql_version >= 90300
 
             ActiveRecord::Base.connection.execute("CREATE TABLE #{table_name}(pk SERIAL, i INTEGER)")
           end
@@ -1287,7 +1287,7 @@ RSpec.describe PgHaMigrations::SafeStatements do
             end
 
             it "uses statement_timeout instead of lock_timeout when on Postgres 9.1" do
-              allow(ActiveRecord::Base.connection).to receive(:postgresql_version).and_return(9_01_12)
+              allow(ActiveRecord::Base.connection).to receive(:postgresql_version).and_return(90112)
               expect do
                 migration.safely_acquire_lock_for_table(table_name) do
                   expect(locks_for_table(table_name, connection: alternate_connection)).not_to be_empty

--- a/spec/safe_statements_spec.rb
+++ b/spec/safe_statements_spec.rb
@@ -512,7 +512,7 @@ RSpec.describe PgHaMigrations::SafeStatements do
         end
 
         describe "safe_add_column" do
-          it "add column of default is not set" do
+          it "add column without a default" do
             migration = Class.new(migration_klass) do
               def up
                 unsafe_create_table :foos

--- a/spec/safe_statements_spec.rb
+++ b/spec/safe_statements_spec.rb
@@ -553,6 +553,38 @@ RSpec.describe PgHaMigrations::SafeStatements do
 
             expect(ActiveRecord::Base.connection.columns("foos").map(&:name)).to include("bar")
           end
+
+          context 'with a version before 11' do
+            before do
+              allow(ActiveRecord::Base.connection).to receive(:postgresql_version).and_return(100000)
+            end
+            
+            it "forbids setting a default" do
+              migration = Class.new(migration_klass) do
+                def up
+                  unsafe_create_table :foos
+                  safe_add_column :foos, :bar, :text, :default => ""
+                end
+              end
+
+              expect do
+                migration.suppress_messages { migration.migrate(:up) }
+              end.to raise_error PgHaMigrations::UnsafeMigrationError
+            end
+
+            it "forbids setting null => false" do
+              migration = Class.new(migration_klass) do
+                def up
+                  unsafe_create_table :foos
+                  safe_add_column :foos, :bar, :text, :null => false
+                end
+              end
+
+              expect do
+                migration.suppress_messages { migration.migrate(:up) }
+              end.to raise_error PgHaMigrations::UnsafeMigrationError
+            end
+          end
         end
 
         describe "safe_change_column_default" do


### PR DESCRIPTION
With PostgreSQL 11, Add Columns including with default values (constant) are now non locking (defaults will be written on page write).
https://www.postgresql.org/docs/11/ddl-alter.html#DDL-ALTER-ADDING-A-COLUMN
https://brandur.org/postgres-default

Test locally in table before and after 15,166 records on small machine

With PG 11
```
=> 15166
➜  ✗ bundle exec rake db:migrate
== 20191125152509 AddColumnToTable: migrating -  ==================
-- add_column(:existing_table, :new_column, :boolean, {:null=>false, :default=>false})
   -> 0.4040s
== 20191125152509 AddColumnToTable: migrated (0.4042s) -  =========
```
With PG 12
```
== 20191125152509 AddColumnToTable: migrating -  ==================
-- add_column(:existing_table, :new_column, :boolean, {:null=>false, :default=>false})
   -> 0.0112s
== 20191125152509 AddColumnToTable migrated (0.0114s) -  =========
```