### PR TITLE
Use underscore notation for postgres version numbers

### DIFF
--- a/lib/pg_ha_migrations/safe_statements.rb
+++ b/lib/pg_ha_migrations/safe_statements.rb
@@ -76,7 +76,7 @@ module PgHaMigrations::SafeStatements
     unless options.is_a?(Hash) && options.key?(:name)
       raise ArgumentError, "Expected safe_remove_concurrent_index to be called with arguments (table_name, :name => ...)"
     end
-    unless ActiveRecord::Base.connection.postgresql_version >= 90600
+    unless ActiveRecord::Base.connection.postgresql_version >= 9_06_00
       raise PgHaMigrations::InvalidMigrationError, "Removing an index concurrently is not supported on Postgres 9.1 databases"
     end
     index_size = select_value("SELECT pg_size_pretty(pg_relation_size('#{options[:name]}'))")
@@ -123,7 +123,7 @@ module PgHaMigrations::SafeStatements
       end
 
       connection.transaction do
-        adjust_timeout_method = connection.postgresql_version >= 90300 ? :adjust_lock_timeout : :adjust_statement_timeout
+        adjust_timeout_method = connection.postgresql_version >= 9_03_00 ? :adjust_lock_timeout : :adjust_statement_timeout
         begin
           method(adjust_timeout_method).call(PgHaMigrations::LOCK_TIMEOUT_SECONDS) do
             connection.execute("LOCK #{quoted_table_name};")

--- a/spec/safe_statements_spec.rb
+++ b/spec/safe_statements_spec.rb
@@ -877,7 +877,7 @@ RSpec.describe PgHaMigrations::SafeStatements do
           end
 
           it "raises if connecting to Postgres 9.1 databases" do
-            allow(ActiveRecord::Base.connection).to receive(:postgresql_version).and_return(90112)
+            allow(ActiveRecord::Base.connection).to receive(:postgresql_version).and_return(9_01_12)
 
             test_migration = Class.new(migration_klass) do
               def up
@@ -948,7 +948,7 @@ RSpec.describe PgHaMigrations::SafeStatements do
           let(:migration) { Class.new(migration_klass).new }
 
           before(:each) do
-            skip "Only relevant on Postgres 9.3+" unless ActiveRecord::Base.connection.postgresql_version >= 90300
+            skip "Only relevant on Postgres 9.3+" unless ActiveRecord::Base.connection.postgresql_version >= 9_03_00
 
             ActiveRecord::Base.connection.execute("CREATE TABLE #{table_name}(pk SERIAL, i INTEGER)")
           end
@@ -1233,7 +1233,7 @@ RSpec.describe PgHaMigrations::SafeStatements do
             end
 
             it "uses statement_timeout instead of lock_timeout when on Postgres 9.1" do
-              allow(ActiveRecord::Base.connection).to receive(:postgresql_version).and_return(90112)
+              allow(ActiveRecord::Base.connection).to receive(:postgresql_version).and_return(9_01_12)
               expect do
                 migration.safely_acquire_lock_for_table(table_name) do
                   expect(locks_for_table(table_name, connection: alternate_connection)).not_to be_empty


### PR DESCRIPTION
To help human readability in the specs of version numbers.