### PR TITLE
Check for default expressions unexpectedly evaluated at DDL time

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,13 @@ unsafe_add_column :table, :column, :type
 Safely change the default value for a column.
 
 ```ruby
+# Constant value:
 safe_change_column_default :table, :column, "value"
+safe_change_column_default :table, :column, DateTime.new(...)
+# Functional expression evaluated at row insert time:
+safe_change_column_default :table, :column, -> { "NOW()" }
+# Functional expression evaluated at migration time:
+safe_change_column_default :table, :column, -> { "'NOW()'" }
 ```
 
 #### safe\_make\_column\_nullable


### PR DESCRIPTION
Previously we skipped implementing this half of our default value
ambiguity checking because it appeared that the only real way to verify
the result wasn't surprising would be to parse the string value. But
after some more thought it turns out we can handle (virtually?) all
cases with a few heuristics. Effectively for non-string-ish types we can
disallow any string-typed values and require specifically typed objects.

In theory there's a possiblity that some custom object could be
coerced-Ruby side into a SQL string that does something weird here, but
I think that's an odd enough case that we can ignore it.