### PR TITLE
Report long transactions without tables locked

### DIFF
--- a/lib/pg_ha_migrations/blocking_database_transactions.rb
+++ b/lib/pg_ha_migrations/blocking_database_transactions.rb
@@ -1,12 +1,22 @@
 module PgHaMigrations
   class BlockingDatabaseTransactions
-    LongRunningTransaction = Struct.new(:database, :current_query, :transaction_age, :tables_with_locks) do
+    LongRunningTransaction = Struct.new(:database, :current_query, :state, :transaction_age, :tables_with_locks) do
       def description
-        "#{database} | tables (#{tables_with_locks.join(', ')}) have been locked for #{transaction_age} | query: #{current_query}"
+        locked_tables = tables_with_locks.compact
+        [
+          database,
+          locked_tables.size > 0 ? "tables (#{locked_tables.join(', ')})" : nil,
+          "#{idle? ? "currently idle " : ""}transaction open for #{transaction_age}",
+          "#{idle? ? "last " : ""}query: #{current_query}"
+        ].compact.join(" | ")
       end
 
       def concurrent_index_creation?
         !!current_query.match(/create\s+index\s+concurrently/i)
+      end
+
+      def idle?
+        state == "idle in transaction"
       end
     end
 
@@ -15,7 +25,7 @@ module PgHaMigrations
     end
 
     def self.find_blocking_transactions(minimum_transaction_age = "0 seconds")
-      pid_column, state_column = if ActiveRecord::Base.connection.select_value("SHOW server_version") =~ /9\.1/
+      pid_column, query_column = if ActiveRecord::Base.connection.select_value("SHOW server_version") =~ /9\.1/
         ["procpid", "current_query"]
       else
         ["pid", "query"]
@@ -24,26 +34,32 @@ module PgHaMigrations
       raw_query = <<-SQL
         SELECT
           psa.datname as database, -- Will only ever be one database
-          psa.#{state_column} as current_query,
+          psa.#{query_column} as current_query,
+          psa.state,
           clock_timestamp() - psa.xact_start AS transaction_age,
           array_agg(distinct c.relname) AS tables_with_locks
         FROM pg_stat_activity psa -- Cluster wide
-          JOIN pg_locks l ON (psa.#{pid_column} = l.pid)  -- Cluster wide
-          JOIN pg_class c ON (l.relation = c.oid) -- Database wide
-          JOIN pg_namespace ns ON (c.relnamespace = ns.oid) -- Database wide
-        WHERE psa.#{pid_column} != pg_backend_pid()
-          AND ns.nspname != 'pg_catalog'
-          AND c.relkind = 'r'
-          AND psa.xact_start < clock_timestamp() - ?::interval
-          AND psa.#{state_column} !~ ?
-          AND (
+          LEFT JOIN pg_locks l ON (psa.#{pid_column} = l.pid)  -- Cluster wide
+          LEFT JOIN pg_class c ON ( -- Database wide
+            l.locktype = 'relation'
+            AND l.relation = c.oid
             -- Be explicit about this being for a single database -- it's already implicit in
             -- the relations used, and if we don't restrict this we could get incorrect results
             -- with oid collisions from pg_namespace and pg_class.
-            l.database = 0
-            OR l.database = (SELECT d.oid FROM pg_database d WHERE d.datname = current_database())
+            AND l.database = (SELECT d.oid FROM pg_database d WHERE d.datname = current_database())
           )
-        GROUP BY psa.datname, psa.#{state_column}, psa.xact_start
+          LEFT JOIN pg_namespace ns ON (c.relnamespace = ns.oid) -- Database wide
+        WHERE psa.#{pid_column} != pg_backend_pid()
+          AND (
+            l.locktype != 'relation'
+            OR (
+               ns.nspname != 'pg_catalog'
+               AND c.relkind = 'r'
+            )
+          )
+          AND psa.xact_start < clock_timestamp() - ?::interval
+          AND psa.#{query_column} !~ ?
+        GROUP BY psa.datname, psa.#{query_column}, psa.state, psa.xact_start
       SQL
 
       query = ActiveRecord::Base.send(:sanitize_sql_for_conditions, [raw_query, minimum_transaction_age, autovacuum_regex])

--- a/spec/blocking_database_transactions_reporter_spec.rb
+++ b/spec/blocking_database_transactions_reporter_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe PgHaMigrations::BlockingDatabaseTransactionsReporter do
       end
     end
 
-    it "Does not puts when no blocking transactions exist" do
+    it "does not puts when no blocking transactions exist" do
       allow(PgHaMigrations::BlockingDatabaseTransactionsReporter).to receive(:get_blocking_transactions).and_return(
         {
           "Primary database" => [],
@@ -84,7 +84,7 @@ RSpec.describe PgHaMigrations::BlockingDatabaseTransactionsReporter do
         expect(PgHaMigrations::BlockingDatabaseTransactionsReporter).to receive(:_puts) do |message|
           expect(message).to match(/Potentially blocking transactions/)
           database = "pg_ha_migrations_test"
-          expect(message).to match(/Primary database:\n\s+#{database} | tables \(foos1, foos2\).*pg_sleep/m)
+          expect(message).to match(/Primary database:\n\s+#{database} \| tables \(foos1, foos2\).*pg_sleep/m)
         end
 
         PgHaMigrations::BlockingDatabaseTransactionsReporter.run

--- a/spec/safe_statements_spec.rb
+++ b/spec/safe_statements_spec.rb
@@ -1216,7 +1216,7 @@ RSpec.describe PgHaMigrations::SafeStatements do
 
                 block_call_count += 1
                 if block_call_count < 3
-                  [PgHaMigrations::BlockingDatabaseTransactions::LongRunningTransaction.new("", "", 5, [table_name.to_s])]
+                  [PgHaMigrations::BlockingDatabaseTransactions::LongRunningTransaction.new("", "", 5, "active", [table_name.to_s])]
                 else
                   []
                 end
@@ -1300,7 +1300,7 @@ RSpec.describe PgHaMigrations::SafeStatements do
               expect(PgHaMigrations::BlockingDatabaseTransactions).to receive(:find_blocking_transactions).exactly(2).times do |*args|
                 blocking_queries_calls += 1
                 if blocking_queries_calls == 1
-                  [PgHaMigrations::BlockingDatabaseTransactions::LongRunningTransaction.new("", "some_sql_query", 5, [table_name.to_s])]
+                  [PgHaMigrations::BlockingDatabaseTransactions::LongRunningTransaction.new("", "some_sql_query", "active", 5, [table_name.to_s])]
                 else
                   []
                 end


### PR DESCRIPTION
Long-running transactions can block some kinds of DDL (at least from
completing) even if they haven't yet locked any tables. For example,
creating an index concurrently has to wait for all in-flight
transactions to complete before its second phase can run.

Along the way I also modified the reporting to show when a transaction
is idle or now and clarify if the query is currently running or is the
most-recently-run query for an idle transaction.