### PR TITLE
Ensure unsafe methods are defined before SafeStatements are loaded

### DIFF
--- a/lib/pg_ha_migrations.rb
+++ b/lib/pg_ha_migrations.rb
@@ -57,8 +57,8 @@ module PgHaMigrations::AutoIncluder
   def inherited(klass)
     super(klass) if defined?(super)
 
-    klass.prepend(PgHaMigrations::SafeStatements)
     klass.prepend(PgHaMigrations::UnsafeStatements)
+    klass.prepend(PgHaMigrations::SafeStatements)
   end
 end
 

--- a/spec/pg_ha_migrations_spec.rb
+++ b/spec/pg_ha_migrations_spec.rb
@@ -81,16 +81,16 @@ RSpec.describe PgHaMigrations do
 
       it "prepends PgHaMigrations modules to the inherited class" do
         expect(subclass.ancestors[0..1]).to eq([
-          PgHaMigrations::UnsafeStatements,
           PgHaMigrations::SafeStatements,
+          PgHaMigrations::UnsafeStatements,
         ])
       end
 
       it "does not include the module more than once" do
         included_modules = subclass.ancestors.select do |ancestor|
           [
-            PgHaMigrations::UnsafeStatements,
             PgHaMigrations::SafeStatements,
+            PgHaMigrations::UnsafeStatements,
           ].include?(ancestor)
         end
 


### PR DESCRIPTION
Prior to this change UnsafeStatements was being prepended after
SafeStatements. SafeStatements overrides several of the unsafe_* methods
which were then being blown away when UnsafeStatements was prepended.

In particular this meant that the SafeStatements implementation of
unsafe_add_column was not being executed, removing any guarantees about
the table being safely locked.