### PR TITLE
Bugfix for safe_change_column_default method

### DIFF
--- a/lib/pg_ha_migrations/safe_statements.rb
+++ b/lib/pg_ha_migrations/safe_statements.rb
@@ -94,6 +94,10 @@ module PgHaMigrations::SafeStatements
       ERROR
     end
 
+    if default_value.nil?
+      default_value = -> { "NULL" }
+    end
+
     safely_acquire_lock_for_table(table_name) do
       unsafe_change_column_default(table_name, column_name, default_value)
     end


### PR DESCRIPTION
This sets the default value of `safe_change_column_default` to `NULL` if the value passed in is `nil`. Previously, it was setting the value to an empty string.

This is the error encountered while trying to run migrations:
```
-- execute("ALTER TABLE \"archive_gateway_transaction_fees\"\nALTER COLUMN \"id\"\nSET DEFAULT ''\n")
rake aborted!
StandardError: An error has occurred, all later migrations canceled:
PG::InvalidTextRepresentation: ERROR:  invalid input syntax for integer: ""
: ALTER TABLE "archive_gateway_transaction_fees"
ALTER COLUMN "id"
SET DEFAULT ''
```