### PR TITLE
Add multiple Postgres versions to the build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,22 @@ sudo: false
 language: ruby
 rvm:
   - 2.5
+global:
+  env:
+    PGPORT: 5433
+env:
+  - PGVERSION: "9.6"
+  - PGVERSION: "10"
+  - PGVERSION: "11"
+  - PGVERSION: "12"
 services:
   - postgresql
-addons:
-  postgresql: "9.6"
 before_install:
+  - sudo service postgresql stop
+  - sudo apt-get update
+  - sudo apt-get -y install postgresql-$PGVERSION postgresql-client-$PGVERSION postgresql-server-dev-$PGVERSION postgresql-client-common postgresql-common
+  - if [ $PGVERSION != '9.6' ]; then sudo cp /etc/postgresql/{9.6,$PGVERSION}/main/pg_hba.conf; fi
+  - sudo service postgresql restart $PGVERSION
   - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
   - gem install bundler -v 1.15.4
 gemfile:


### PR DESCRIPTION
We have different behavior at different versions, so we might as well
test that out in CI.

For PG12, I had to make a few changes to tests using consrc and adsrc
catalog attributes, since those have been removed.