### PR TITLE
Allow setting a default value in safe_add_column for PostgreSQL 11+

### DIFF
--- a/lib/pg_ha_migrations/safe_statements.rb
+++ b/lib/pg_ha_migrations/safe_statements.rb
@@ -27,12 +27,10 @@ module PgHaMigrations::SafeStatements
 
   def safe_add_column(table, column, type, options = {})
     if options.has_key?(:default)
-      if ActiveRecord::Base.connection.postgresql_version <= 11_00_00
+      if ActiveRecord::Base.connection.postgresql_version < 11_00_00
         raise PgHaMigrations::UnsafeMigrationError.new(":default is NOT SAFE! Use safe_change_column_default afterwards then backfill the data to prevent locking the table")
-      else
-        if options[:default].is_a?(Proc) || (options[:default].is_a?(String) && !([:string, :text, :binary].include?(type.to_sym) || _type_is_enum(type)))
-          raise PgHaMigrations::UnsafeMigrationError.new(":default is not safe if the default value is volatile. Use safe_change_column_default afterwards then backfill the data to prevent locking the table")
-        end
+      elsif options[:default].is_a?(Proc) || (options[:default].is_a?(String) && !([:string, :text, :binary].include?(type.to_sym) || _type_is_enum(type)))
+        raise PgHaMigrations::UnsafeMigrationError.new(":default is not safe if the default value is volatile. Use safe_change_column_default afterwards then backfill the data to prevent locking the table")
       end
     end
     if options[:null] == false

--- a/spec/safe_statements_spec.rb
+++ b/spec/safe_statements_spec.rb
@@ -572,7 +572,7 @@ RSpec.describe PgHaMigrations::SafeStatements do
               migration = Class.new(migration_klass) do
                 define_method(:up) do
                   unsafe_create_table :foos
-                  ActiveRecord::Base.connection.execute("INSERT INTO foos SELECT FROM (VALUES (1)) t")
+                  ActiveRecord::Base.connection.execute("INSERT INTO foos(bar) VALUES (1)")
                   if type == :enum
                     safe_create_enum_type :bt_foo_enum, ["NOW()"]
                     safe_add_column :foos, :bar, :bt_foo_enum, :default => 'NOW()'

--- a/spec/safe_statements_spec.rb
+++ b/spec/safe_statements_spec.rb
@@ -552,7 +552,7 @@ RSpec.describe PgHaMigrations::SafeStatements do
             migration = Class.new(migration_klass) do
               def up
                 unsafe_create_table :foos
-                ActiveRecord::Base.connection.execute("INSERT INTO foos(bar) VALUES (1)")
+                ActiveRecord::Base.connection.execute("INSERT INTO foos(id) VALUES (1)")
                 safe_add_column :foos, :bar, :text, :default => "baz"
               end
             end
@@ -572,7 +572,7 @@ RSpec.describe PgHaMigrations::SafeStatements do
               migration = Class.new(migration_klass) do
                 define_method(:up) do
                   unsafe_create_table :foos
-                  ActiveRecord::Base.connection.execute("INSERT INTO foos(bar) VALUES (1)")
+                  ActiveRecord::Base.connection.execute("INSERT INTO foos(id) VALUES (1)")
                   if type == :enum
                     safe_create_enum_type :bt_foo_enum, ["NOW()"]
                     safe_add_column :foos, :bar, :bt_foo_enum, :default => 'NOW()'
@@ -589,7 +589,7 @@ RSpec.describe PgHaMigrations::SafeStatements do
                 expected_value = type == :binary ? "\\x4e4f572829" : "NOW()"
                 expect(ActiveRecord::Base.connection.columns("foos").detect { |column| column.name == "bar" }.default).to eq(expected_value)
 
-                ActiveRecord::Base.connection.execute("INSERT INTO foos(bar) VALUES (1)")
+                ActiveRecord::Base.connection.execute("INSERT INTO foos(id) VALUES (1)")
                 expect(ActiveRecord::Base.connection.select_value("SELECT bar FROM foos")).to eq(expected_value)
               else
                 expect do

--- a/spec/safe_statements_spec.rb
+++ b/spec/safe_statements_spec.rb
@@ -568,7 +568,7 @@ RSpec.describe PgHaMigrations::SafeStatements do
           end
 
           [:string, :text, :enum, :binary].each do |type|
-            it "allows a default value that looks like an expression for the #{type.inspect} type" do
+            it "allows a default value that looks like an expression for the #{type.inspect} type on Postgres 11+" do
               migration = Class.new(migration_klass) do
                 define_method(:up) do
                   unsafe_create_table :foos

--- a/spec/safe_statements_spec.rb
+++ b/spec/safe_statements_spec.rb
@@ -589,7 +589,7 @@ RSpec.describe PgHaMigrations::SafeStatements do
                 expected_value = type == :binary ? "\\x4e4f572829" : "NOW()"
                 expect(ActiveRecord::Base.connection.columns("foos").detect { |column| column.name == "bar" }.default).to eq(expected_value)
 
-                ActiveRecord::Base.connection.execute("INSERT INTO foos SELECT FROM (VALUES (1)) t")
+                ActiveRecord::Base.connection.execute("INSERT INTO foos(bar) VALUES (1)")
                 expect(ActiveRecord::Base.connection.select_value("SELECT bar FROM foos")).to eq(expected_value)
               else
                 expect do

--- a/spec/safe_statements_spec.rb
+++ b/spec/safe_statements_spec.rb
@@ -552,7 +552,7 @@ RSpec.describe PgHaMigrations::SafeStatements do
             migration = Class.new(migration_klass) do
               def up
                 unsafe_create_table :foos
-                ActiveRecord::Base.connection.execute("INSERT INTO foos SELECT FROM (VALUES (1)) t")
+                ActiveRecord::Base.connection.execute("INSERT INTO foos(bar) VALUES (1)")
                 safe_add_column :foos, :bar, :text, :default => "baz"
               end
             end


### PR DESCRIPTION
> From PostgreSQL 11, adding a column with a constant default value no
> longer means that each row of the table needs to be updated when the
> ALTER TABLE statement is executed. Instead, the default value will be
> returned the next time the row is accessed, and applied when the table
> is rewritten, making the ALTER TABLE very fast even on large tables.

https://www.postgresql.org/docs/11/ddl-alter.html#DDL-ALTER-ADDING-A-COLUMN