### PR TITLE
Enable default password and pg version in bin/setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -2,6 +2,9 @@
 set -euo pipefail
 IFS=$'\n\t'
 set -vx
+export PGPASSWORD="${PGPASSWORD:-postgres}"
+PGVERSION="${PGVERSION:-13}"
+
 
 bundle install
 bundle exec appraisal install
@@ -9,4 +12,4 @@ bundle exec appraisal install
 # Do any other automated setup that you need to do here
 
 # Launch a blank postgres image for testing
-docker run -d -p 127.0.0.1:5432:5432 postgres:10
+docker run -d -p 127.0.0.1:5432:5432 -e POSTGRES_PASSWORD="${PGPASSWORD}" postgres:${PGVERSION}


### PR DESCRIPTION
I hit a few small bumps when running bin/setup and tests. 
Changes:
- The docker container stops if there is no `POSTGRES_PASSWORD` env var set for postgres to use on startup, so this sets it to the same password the specs use to connect to the postgres container
- This updates the default postgres version, and enables the user to specify a different version when running the script