### PR TITLE
Make error classes inherit from StandardError not Exception

### DIFF
--- a/lib/pg_ha_migrations.rb
+++ b/lib/pg_ha_migrations.rb
@@ -29,18 +29,18 @@ module PgHaMigrations
   # Safe versus unsafe in this context specifically means the following:
   # - Safe operations will not block for long periods of time.
   # - Unsafe operations _may_ block for long periods of time.
-  UnsafeMigrationError = Class.new(Exception)
+  UnsafeMigrationError = Class.new(StandardError)
 
   # Invalid migrations are operations which we expect to not function
   # as expected or get the schema into an inconsistent state
-  InvalidMigrationError = Class.new(Exception)
+  InvalidMigrationError = Class.new(StandardError)
 
   # Unsupported migrations use ActiveRecord::Migration features that
   # we don't support, and therefore will likely have unexpected behavior.
-  UnsupportedMigrationError = Class.new(Exception)
+  UnsupportedMigrationError = Class.new(StandardError)
 
   # This gem only supports the PostgreSQL adapter at this time.
-  UnsupportedAdapter = Class.new(Exception)
+  UnsupportedAdapter = Class.new(StandardError)
 end
 
 require "pg_ha_migrations/blocking_database_transactions"


### PR DESCRIPTION
The error classes are named with the suffix `Error` anyway, so it's
confusing that they inherit from Ruby's `Exception` class. That's not a
nice surprise since `Exception` is conventionally special in the Ruby
world.

That being said we don't expect anyone to be rescuing these errors, but
it seems unnecessary to prevent it this way.