### PR TITLE
Raise error when adding column and default in two steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ safe_change_column_default :table, :column, -> { "NOW()" }
 safe_change_column_default :table, :column, -> { "'NOW()'" }
 ```
 
+Note: On Postgres 11+ adding a column with a constant default value does not rewrite or scan the table (under a lock or otherwise). In that case a migration adding a column with a default should do so in a single operation rather than the two-step `safe_add_column` followed by `safe_change_column_default`. We enforce this best practice with the error `PgHaMigrations::BestPracticeError`, but if your prefer otherwise (or are running in a mixed Postgres version environment), you may opt out by setting `config.prefer_single_step_column_addition_with_default = true` [in your configuration initializer](#configuration).
+
 #### safe\_make\_column\_nullable
 
 Safely make the column nullable.
@@ -272,6 +274,7 @@ end
 
 - `disable_default_migration_methods`: If true, the default implementations of DDL changes in `ActiveRecord::Migration` and the PostgreSQL adapter will be overridden by implementations that raise a `PgHaMigrations::UnsafeMigrationError`. Default: `true`
 - `check_for_dependent_objects`: If true, some `unsafe_*` migration methods will raise a `PgHaMigrations::UnsafeMigrationError` if any dependent objects exist. Default: `false`
+- `prefer_single_step_column_addition_with_default`: If `true`, raise an error when adding a column and separately setting a constant default value for that column in the same migration.
 
 ### Rake Tasks
 

--- a/lib/pg_ha_migrations.rb
+++ b/lib/pg_ha_migrations.rb
@@ -8,14 +8,16 @@ module PgHaMigrations
   Config = Struct.new(
     :disable_default_migration_methods,
     :check_for_dependent_objects,
-    :allow_force_create_table
+    :allow_force_create_table,
+    :prefer_single_step_column_addition_with_default
   )
 
   def self.config
     @config ||= Config.new(
       true,
       false,
-      true
+      true,
+      false
     )
   end
 
@@ -34,6 +36,12 @@ module PgHaMigrations
   # Invalid migrations are operations which we expect to not function
   # as expected or get the schema into an inconsistent state
   InvalidMigrationError = Class.new(Exception)
+
+  # Operations violating a best practice, but not actually unsafe will
+  # raise this error. For example, adding a column without a default and
+  # then setting its default in a second action in a single migration
+  # isn't our documented best practice and will raise this error.
+  BestPracticeError = Class.new(Exception)
 
   # Unsupported migrations use ActiveRecord::Migration features that
   # we don't support, and therefore will likely have unexpected behavior.


### PR DESCRIPTION
As of Postgres 11+ we prefer to add a column with a default (assuming
the value is constant) in a single step rather than, in the same
migration, adding the column and separately setting the default.

Fixes #64.