### PR TITLE
Support for creating partitioned tables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
           - 12
           - 13
           - 14
+          - 15
         ruby:
           - 2.7
         gemfile:
@@ -40,6 +41,9 @@ jobs:
             ruby: 3.0
             pg: 14
           - gemfile: rails_6.1
+            ruby: 3.0
+            pg: 15
+          - gemfile: rails_6.1
             ruby: 3.1
             pg: 9.6
           - gemfile: rails_6.1
@@ -57,6 +61,9 @@ jobs:
           - gemfile: rails_6.1
             ruby: 3.1
             pg: 14
+          - gemfile: rails_6.1
+            ruby: 3.1
+            pg: 15
           - gemfile: rails_7.0
             ruby: 3.0
             pg: 9.6
@@ -76,6 +83,9 @@ jobs:
             ruby: 3.0
             pg: 14
           - gemfile: rails_7.0
+            ruby: 3.0
+            pg: 15
+          - gemfile: rails_7.0
             ruby: 3.1
             pg: 9.6
           - gemfile: rails_7.0
@@ -93,6 +103,9 @@ jobs:
           - gemfile: rails_7.0
             ruby: 3.1
             pg: 14
+          - gemfile: rails_7.0
+            ruby: 3.1
+            pg: 15
     name: PostgreSQL ${{ matrix.pg }}
     runs-on: ubuntu-latest
     env: # $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ jobs:
           - 10
           - 11
           - 12
+          - 13
+          - 14
         ruby:
           - 2.7
         gemfile:
@@ -32,6 +34,12 @@ jobs:
             ruby: 3.0
             pg: 12
           - gemfile: rails_6.1
+            ruby: 3.0
+            pg: 13
+          - gemfile: rails_6.1
+            ruby: 3.0
+            pg: 14
+          - gemfile: rails_6.1
             ruby: 3.1
             pg: 9.6
           - gemfile: rails_6.1
@@ -43,6 +51,12 @@ jobs:
           - gemfile: rails_6.1
             ruby: 3.1
             pg: 12
+          - gemfile: rails_6.1
+            ruby: 3.1
+            pg: 13
+          - gemfile: rails_6.1
+            ruby: 3.1
+            pg: 14
           - gemfile: rails_7.0
             ruby: 3.0
             pg: 9.6
@@ -56,6 +70,12 @@ jobs:
             ruby: 3.0
             pg: 12
           - gemfile: rails_7.0
+            ruby: 3.0
+            pg: 13
+          - gemfile: rails_7.0
+            ruby: 3.0
+            pg: 14
+          - gemfile: rails_7.0
             ruby: 3.1
             pg: 9.6
           - gemfile: rails_7.0
@@ -67,6 +87,12 @@ jobs:
           - gemfile: rails_7.0
             ruby: 3.1
             pg: 12
+          - gemfile: rails_7.0
+            ruby: 3.1
+            pg: 13
+          - gemfile: rails_7.0
+            ruby: 3.1
+            pg: 14
     name: PostgreSQL ${{ matrix.pg }}
     runs-on: ubuntu-latest
     env: # $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
           - gemfile: rails_7.0
             ruby: 3.1
             pg: 15
-    name: PostgreSQL ${{ matrix.pg }}
+    name: PostgreSQL ${{ matrix.pg }} - Ruby ${{ matrix.ruby }} - ${{ matrix.gemfile }}
     runs-on: ubuntu-latest
     env: # $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile

--- a/Appraisals
+++ b/Appraisals
@@ -19,5 +19,5 @@ appraise "rails-6.1" do
 end
 
 appraise "rails-7.0" do
-  gem "rails", "7.0.0"
+  gem "rails", "7.0.1"
 end

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ safe_create_partitioned_table :table, :type: :hash, key: ->{ "(example_column::d
 end
 ```
 
-The identifier column is `bigserial` by default. This can be overridden, as you would in `safe_create_table`, by setting the `id` argument:
+The identifier column type is `bigserial` by default. This can be overridden, as you would in `safe_create_table`, by setting the `id` argument:
 
 ```ruby
 safe_create_partitioned_table :table, id: :serial, type: :range, key: :example_column do |t|

--- a/README.md
+++ b/README.md
@@ -220,6 +220,50 @@ Drop any (not just `CHECK`) constraint.
 unsafe_remove_constraint :table, name: :constraint_table_on_column_like_example
 ```
 
+#### safe\_create\_partitioned\_table
+
+Safely create a new partitioned table using [declaritive partitioning](https://www.postgresql.org/docs/15/ddl-partitioning.html#DDL-PARTITIONING-DECLARATIVE).
+
+```ruby
+# list partitioned table using single column as partition key
+safe_create_partitioned_table :table, type: :list, key: :example_column do |t|
+  t.text :example_column, null: false
+end
+
+# range partitioned table using multiple columns as partition key
+safe_create_partitioned_table :table, type: :range, key: [:example_column_a, :example_column_b] do |t|
+  t.integer :example_column_a, null: false
+  t.integer :example_column_b, null: false
+end
+
+# hash partitioned table using expression as partition key
+safe_create_partitioned_table :table, :type: :hash, key: ->{ "(example_column::date)" } do |t|
+  t.datetime :example_column, null: false
+end
+```
+
+The identifier column is `bigserial` by default. This can be overridden, as you would in `safe_create_table`, by setting the `id` argument:
+
+```ruby
+safe_create_partitioned_table :table, id: :serial, type: :range, key: :example_column do |t|
+  t.date :example_column, null: false
+end
+```
+
+In PostgreSQL 11+, primary key constraints are supported on partitioned tables given the partition key is included. On supported versions, the primary key is inferred by default. This functionality can be disabled by setting the `infer_primary_key` argument to `false`:
+
+```ruby
+# primary key will be (id, example_column)
+safe_create_partitioned_table :table, type: :range, key: :example_column do |t|
+  t.date :example_column, null: false
+end
+
+# primary key will not be created
+safe_create_partitioned_table :table, type: :range, key: :example_column, infer_primary_key: false do |t|
+  t.date :example_column, null: false
+end
+```
+
 ### Utilities
 
 #### safely\_acquire\_lock\_for\_table

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ unsafe_remove_constraint :table, name: :constraint_table_on_column_like_example
 
 #### safe\_create\_partitioned\_table
 
-Safely create a new partitioned table using [declaritive partitioning](https://www.postgresql.org/docs/15/ddl-partitioning.html#DDL-PARTITIONING-DECLARATIVE).
+Safely create a new partitioned table using [declaritive partitioning](https://www.postgresql.org/docs/current/ddl-partitioning.html#DDL-PARTITIONING-DECLARATIVE).
 
 ```ruby
 # list partitioned table using single column as partition key
@@ -250,7 +250,7 @@ safe_create_partitioned_table :table, id: :serial, type: :range, key: :example_c
 end
 ```
 
-In PostgreSQL 11+, primary key constraints are supported on partitioned tables given the partition key is included. On supported versions, the primary key is inferred by default. This functionality can be disabled by setting the `infer_primary_key` argument to `false`:
+In PostgreSQL 11+, primary key constraints are supported on partitioned tables given the partition key is included. On supported versions, the primary key is inferred by default (see [available options](#available-options)). This functionality can be overridden by setting the `infer_primary_key` argument.
 
 ```ruby
 # primary key will be (id, example_column)
@@ -318,8 +318,9 @@ end
 
 - `disable_default_migration_methods`: If true, the default implementations of DDL changes in `ActiveRecord::Migration` and the PostgreSQL adapter will be overridden by implementations that raise a `PgHaMigrations::UnsafeMigrationError`. Default: `true`
 - `check_for_dependent_objects`: If true, some `unsafe_*` migration methods will raise a `PgHaMigrations::UnsafeMigrationError` if any dependent objects exist. Default: `false`
-- `prefer_single_step_column_addition_with_default`: If `true`, raise an error when adding a column and separately setting a constant default value for that column in the same migration. Default: `false`
+- `prefer_single_step_column_addition_with_default`: If true, raise an error when adding a column and separately setting a constant default value for that column in the same migration. Default: `false`
 - `allow_force_create_table`: If false, the `force: true` option to ActiveRecord's `create_table` method is disallowed. Default: `true`
+- `infer_primary_key_on_partitioned_tables`: If true, the primary key for partitioned tables will be inferred on PostgreSQL 11+ databases (identifier column + partition key columns). Default: `true`
 
 ### Rake Tasks
 

--- a/lib/pg_ha_migrations.rb
+++ b/lib/pg_ha_migrations.rb
@@ -10,7 +10,8 @@ module PgHaMigrations
     :disable_default_migration_methods,
     :check_for_dependent_objects,
     :allow_force_create_table,
-    :prefer_single_step_column_addition_with_default
+    :prefer_single_step_column_addition_with_default,
+    :infer_primary_key_on_partitioned_tables,
   )
 
   def self.config
@@ -18,7 +19,8 @@ module PgHaMigrations
       true,
       false,
       true,
-      false
+      false,
+      true
     )
   end
 

--- a/lib/pg_ha_migrations/safe_statements.rb
+++ b/lib/pg_ha_migrations/safe_statements.rb
@@ -226,7 +226,7 @@ module PgHaMigrations::SafeStatements
     end
   end
 
-  def safe_create_partitioned_table(table, key:, type:, infer_primary_key: true, **options, &block)
+  def safe_create_partitioned_table(table, key:, type:, infer_primary_key: nil, **options, &block)
     raise ArgumentError, "Expected <key> to be present" unless key.present?
 
     unless VALID_PARTITION_TYPES.include?(type)
@@ -239,6 +239,10 @@ module PgHaMigrations::SafeStatements
 
     if type == :hash && ActiveRecord::Base.connection.postgresql_version < 11_00_00
       raise PgHaMigrations::InvalidMigrationError, "Hash partitioning not supported on Postgres databases before version 11"
+    end
+
+    if infer_primary_key.nil?
+      infer_primary_key = PgHaMigrations.config.infer_primary_key_on_partitioned_tables
     end
 
     # Newer versions of Rails will set the primary key column to the type :primary_key.

--- a/lib/pg_ha_migrations/safe_statements.rb
+++ b/lib/pg_ha_migrations/safe_statements.rb
@@ -1,4 +1,6 @@
 module PgHaMigrations::SafeStatements
+  VALID_PARTITION_TYPES = %i[range list hash]
+
   def safe_added_columns_without_default_value
     @safe_added_columns_without_default_value ||= []
   end
@@ -221,6 +223,72 @@ module PgHaMigrations::SafeStatements
       say_with_time "remove_constraint(#{table.inspect}, name: #{name.inspect})" do
         connection.execute(sql)
       end
+    end
+  end
+
+  def safe_create_partition(table, options={}, &block)
+    partition_key = options.fetch(:key) { raise ArgumentError, "Expected <key> to be present" }
+    partition_type = options.fetch(:type) { raise ArgumentError, "Expected <type> to be present" }.to_sym
+    infer_pk = options.fetch(:infer_pk, true)
+
+    unless VALID_PARTITION_TYPES.include?(partition_type)
+      raise ArgumentError, "Expected <type> to be in #{VALID_PARTITION_TYPES}. Received :#{partition_type}."
+    end
+
+    if ActiveRecord::Base.connection.postgresql_version < 10_00_00
+      raise PgHaMigrations::InvalidMigrationError, "Native partitioning not supported on Postgres databases before version 10"
+    end
+
+    if partition_type == :hash && ActiveRecord::Base.connection.postgresql_version < 11_00_00
+      raise PgHaMigrations::InvalidMigrationError, "Hash partitioning not supported on Postgres databases before version 11"
+    end
+
+    passthrough_options = options.except(:key, :type, :infer_pk)
+
+    # Newer versions of Rails will set the primary key column to the type :primary_key.
+    # This performs some extra logic that we can't easily undo which causes problems when
+    # trying to inject the partition key into the PK. Now, it would be nice to lookup the
+    # default primary key type instead of simply using :bigserial, but it doesn't appear
+    # that we have access to the Rails configuration from within our migrations:
+    #
+    # [6] pry(#<#<Class:0x000055d69c45f470>>)> Rails.configuration
+    # NoMethodError: undefined method `config' for nil:NilClass
+    if passthrough_options[:id].nil? || passthrough_options[:id] == :primary_key
+      passthrough_options[:id] = :bigserial
+    end
+
+    passthrough_options[:options] = "PARTITION BY #{partition_type.upcase} (#{_quote_partition_key(partition_key)})"
+
+    safe_create_table(table, passthrough_options) do |td|
+      yield(td) if block_given?
+
+      next unless passthrough_options[:id]
+
+      pk_columns = td.columns.each_with_object([]) do |col, arr|
+        if col.respond_to?(:primary_key)
+          next unless col.primary_key
+
+          col.primary_key = false
+        else
+          next unless col.options[:primary_key]
+
+          col.options[:primary_key] = false
+        end
+
+        arr << col.name
+      end
+
+      if infer_pk && !partition_key.is_a?(Proc) && ActiveRecord::Base.connection.postgresql_version >= 11_00_00
+        td.primary_keys(pk_columns.concat(Array.wrap(partition_key)).map(&:to_s).uniq)
+      end
+    end
+  end
+
+  def _quote_partition_key(key)
+    if key.is_a?(Proc)
+      key.call.to_s # very hard to sanitize a complex expression
+    else
+      Array.wrap(key).map { |col| connection.quote_column_name(col) }.join(",")
     end
   end
 

--- a/lib/pg_ha_migrations/safe_statements.rb
+++ b/lib/pg_ha_migrations/safe_statements.rb
@@ -227,8 +227,10 @@ module PgHaMigrations::SafeStatements
   end
 
   def safe_create_partitioned_table(table, key:, type:, infer_primary_key: true, **options, &block)
+    raise ArgumentError, "Expected <key> to be present" unless key.present?
+
     unless VALID_PARTITION_TYPES.include?(type)
-      raise ArgumentError, "Expected <type> to be in #{VALID_PARTITION_TYPES}. Received :#{type}."
+      raise ArgumentError, "Expected <type> to be symbol in #{VALID_PARTITION_TYPES}"
     end
 
     if ActiveRecord::Base.connection.postgresql_version < 10_00_00

--- a/spec/pg_ha_migrations_spec.rb
+++ b/spec/pg_ha_migrations_spec.rb
@@ -55,6 +55,34 @@ RSpec.describe PgHaMigrations do
         expect(PgHaMigrations.config.allow_force_create_table).to be(false)
       end
     end
+
+    context "prefer_single_step_column_addition_with_default" do
+      it "is set to false by default" do
+        expect(PgHaMigrations.config.prefer_single_step_column_addition_with_default).to be(false)
+      end
+
+      it "can be overriden to true" do
+        PgHaMigrations.configure do |config|
+          config.prefer_single_step_column_addition_with_default = true
+        end
+
+        expect(PgHaMigrations.config.prefer_single_step_column_addition_with_default).to be(true)
+      end
+    end
+
+    context "infer_primary_key_on_partitioned_tables" do
+      it "is set to true by default" do
+        expect(PgHaMigrations.config.infer_primary_key_on_partitioned_tables).to be(true)
+      end
+
+      it "can be overriden to false" do
+        PgHaMigrations.configure do |config|
+          config.infer_primary_key_on_partitioned_tables = false
+        end
+
+        expect(PgHaMigrations.config.infer_primary_key_on_partitioned_tables).to be(false)
+      end
+    end
   end
 
   PgHaMigrations::AllowedVersions::ALLOWED_VERSIONS.each do |migration_klass|

--- a/spec/safe_statements_spec.rb
+++ b/spec/safe_statements_spec.rb
@@ -2042,7 +2042,22 @@ RSpec.describe PgHaMigrations::SafeStatements do
 
             expect do
               migration.suppress_messages { migration.migrate(:up) }
-            end.to raise_error(ArgumentError, "Expected <type> to be in [:range, :list, :hash]. Received :garbage.")
+            end.to raise_error(ArgumentError, "Expected <type> to be symbol in [:range, :list, :hash]")
+          end
+
+          it "raises when partition key is not present" do
+            migration = Class.new(migration_klass) do
+              def up
+                safe_create_partitioned_table :foos3, type: :range, key: nil do |t|
+                  t.timestamps :null => false
+                  t.text :text_column
+                end
+              end
+            end
+
+            expect do
+              migration.suppress_messages { migration.migrate(:up) }
+            end.to raise_error(ArgumentError, "Expected <key> to be present")
           end
 
           it "raises when pg version < 10" do

--- a/spec/safe_statements_spec.rb
+++ b/spec/safe_statements_spec.rb
@@ -2030,6 +2030,36 @@ RSpec.describe PgHaMigrations::SafeStatements do
             expect(pk).to be_empty
           end
 
+          it "raises when partition key is missing" do
+            migration = Class.new(migration_klass) do
+              def up
+                safe_create_partition :foos3, type: :range do |t|
+                  t.timestamps :null => false
+                  t.text :text_column
+                end
+              end
+            end
+
+            expect do
+              migration.suppress_messages { migration.migrate(:up) }
+            end.to raise_error(ArgumentError, "Expected <key> to be present")
+          end
+
+          it "raises when partition type is missing" do
+            migration = Class.new(migration_klass) do
+              def up
+                safe_create_partition :foos3, key: :created_at do |t|
+                  t.timestamps :null => false
+                  t.text :text_column
+                end
+              end
+            end
+
+            expect do
+              migration.suppress_messages { migration.migrate(:up) }
+            end.to raise_error(ArgumentError, "Expected <type> to be present")
+          end
+
           it "raises when partition type is invalid" do
             migration = Class.new(migration_klass) do
               def up

--- a/spec/safe_statements_spec.rb
+++ b/spec/safe_statements_spec.rb
@@ -1764,13 +1764,13 @@ RSpec.describe PgHaMigrations::SafeStatements do
           end
         end
 
-        describe "safe_create_partition" do
+        describe "safe_create_partitioned_table" do
           it "creates range partition" do
             skip "Only relevant on Postgres 10+" unless ActiveRecord::Base.connection.postgresql_version >= 10_00_00
 
             migration = Class.new(migration_klass) do
               def up
-                safe_create_partition :foos3, type: :range, key: :created_at do |t|
+                safe_create_partitioned_table :foos3, type: :range, key: :created_at do |t|
                   t.timestamps :null => false
                   t.text :text_column
                 end
@@ -1794,7 +1794,7 @@ RSpec.describe PgHaMigrations::SafeStatements do
 
             migration = Class.new(migration_klass) do
               def up
-                safe_create_partition :foos3, type: :list, key: :created_at do |t|
+                safe_create_partitioned_table :foos3, type: :list, key: :created_at do |t|
                   t.timestamps :null => false
                   t.text :text_column
                 end
@@ -1818,7 +1818,7 @@ RSpec.describe PgHaMigrations::SafeStatements do
 
             migration = Class.new(migration_klass) do
               def up
-                safe_create_partition :foos3, type: :hash, key: :created_at do |t|
+                safe_create_partitioned_table :foos3, type: :hash, key: :created_at do |t|
                   t.timestamps :null => false
                   t.text :text_column
                 end
@@ -1842,7 +1842,7 @@ RSpec.describe PgHaMigrations::SafeStatements do
 
             migration = Class.new(migration_klass) do
               def up
-                safe_create_partition :foos3, type: :range, key: :created_at do |t|
+                safe_create_partitioned_table :foos3, type: :range, key: :created_at do |t|
                   t.timestamps :null => false
                   t.text :text_column
                 end
@@ -1861,7 +1861,7 @@ RSpec.describe PgHaMigrations::SafeStatements do
 
             migration = Class.new(migration_klass) do
               def up
-                safe_create_partition :foos3, type: :range, key: :created_at, primary_key: :pk do |t|
+                safe_create_partitioned_table :foos3, type: :range, key: :created_at, primary_key: :pk do |t|
                   t.timestamps :null => false
                   t.text :text_column
                 end
@@ -1880,7 +1880,7 @@ RSpec.describe PgHaMigrations::SafeStatements do
 
             migration = Class.new(migration_klass) do
               def up
-                safe_create_partition :foos3, type: :range, key: :pk, primary_key: :pk do |t|
+                safe_create_partitioned_table :foos3, type: :range, key: :pk, primary_key: :pk do |t|
                   t.timestamps :null => false
                   t.text :text_column
                 end
@@ -1899,7 +1899,7 @@ RSpec.describe PgHaMigrations::SafeStatements do
 
             migration = Class.new(migration_klass) do
               def up
-                safe_create_partition :foos3, type: :range, key: ->{ "(created_at::date)" } do |t|
+                safe_create_partitioned_table :foos3, type: :range, key: ->{ "(created_at::date)" } do |t|
                   t.timestamps :null => false
                   t.text :text_column
                 end
@@ -1918,7 +1918,7 @@ RSpec.describe PgHaMigrations::SafeStatements do
 
             migration = Class.new(migration_klass) do
               def up
-                safe_create_partition :foos3, type: :range, key: [:created_at, :text_column] do |t|
+                safe_create_partitioned_table :foos3, type: :range, key: [:created_at, :text_column] do |t|
                   t.timestamps :null => false
                   t.text :text_column
                 end
@@ -1932,12 +1932,12 @@ RSpec.describe PgHaMigrations::SafeStatements do
             expect(pk).to eq(["id", "created_at", "text_column"])
           end
 
-          it "does not create pk when infer_pk is false" do
+          it "does not create pk when infer_primary_key is false" do
             skip "Only relevant on Postgres 11+" unless ActiveRecord::Base.connection.postgresql_version >= 11_00_00
 
             migration = Class.new(migration_klass) do
               def up
-                safe_create_partition :foos3, type: :range, infer_pk: false, key: [:created_at, :text_column] do |t|
+                safe_create_partitioned_table :foos3, type: :range, infer_primary_key: false, key: [:created_at, :text_column] do |t|
                   t.timestamps :null => false
                   t.text :text_column
                 end
@@ -1956,7 +1956,7 @@ RSpec.describe PgHaMigrations::SafeStatements do
 
             migration = Class.new(migration_klass) do
               def up
-                safe_create_partition :foos3, type: :range, id: false, key: :created_at do |t|
+                safe_create_partitioned_table :foos3, type: :range, id: false, key: :created_at do |t|
                   t.timestamps :null => false
                   t.text :text_column
                 end
@@ -1975,7 +1975,7 @@ RSpec.describe PgHaMigrations::SafeStatements do
 
             migration = Class.new(migration_klass) do
               def up
-                safe_create_partition :foos3, type: :range, key: :created_at do |t|
+                safe_create_partitioned_table :foos3, type: :range, key: :created_at do |t|
                   t.timestamps :null => false
                   t.text :text_column
                 end
@@ -1995,7 +1995,7 @@ RSpec.describe PgHaMigrations::SafeStatements do
 
             migration = Class.new(migration_klass) do
               def up
-                safe_create_partition :foos3, type: :range, key: :created_at, id: :serial do |t|
+                safe_create_partitioned_table :foos3, type: :range, key: :created_at, id: :serial do |t|
                   t.timestamps :null => false
                   t.text :text_column
                 end
@@ -2016,7 +2016,7 @@ RSpec.describe PgHaMigrations::SafeStatements do
 
             migration = Class.new(migration_klass) do
               def up
-                safe_create_partition :foos3, type: :range, key: :created_at do |t|
+                safe_create_partitioned_table :foos3, type: :range, key: :created_at do |t|
                   t.timestamps :null => false
                   t.text :text_column
                 end
@@ -2030,40 +2030,10 @@ RSpec.describe PgHaMigrations::SafeStatements do
             expect(pk).to be_empty
           end
 
-          it "raises when partition key is missing" do
-            migration = Class.new(migration_klass) do
-              def up
-                safe_create_partition :foos3, type: :range do |t|
-                  t.timestamps :null => false
-                  t.text :text_column
-                end
-              end
-            end
-
-            expect do
-              migration.suppress_messages { migration.migrate(:up) }
-            end.to raise_error(ArgumentError, "Expected <key> to be present")
-          end
-
-          it "raises when partition type is missing" do
-            migration = Class.new(migration_klass) do
-              def up
-                safe_create_partition :foos3, key: :created_at do |t|
-                  t.timestamps :null => false
-                  t.text :text_column
-                end
-              end
-            end
-
-            expect do
-              migration.suppress_messages { migration.migrate(:up) }
-            end.to raise_error(ArgumentError, "Expected <type> to be present")
-          end
-
           it "raises when partition type is invalid" do
             migration = Class.new(migration_klass) do
               def up
-                safe_create_partition :foos3, type: :garbage, key: :created_at do |t|
+                safe_create_partitioned_table :foos3, type: :garbage, key: :created_at do |t|
                   t.timestamps :null => false
                   t.text :text_column
                 end
@@ -2080,7 +2050,7 @@ RSpec.describe PgHaMigrations::SafeStatements do
 
             migration = Class.new(migration_klass) do
               def up
-                safe_create_partition :foos3, type: :range, key: :created_at do |t|
+                safe_create_partitioned_table :foos3, type: :range, key: :created_at do |t|
                   t.timestamps :null => false
                   t.text :text_column
                 end
@@ -2098,7 +2068,7 @@ RSpec.describe PgHaMigrations::SafeStatements do
 
             migration = Class.new(migration_klass) do
               def up
-                safe_create_partition :foos3, type: :hash, key: :created_at do |t|
+                safe_create_partitioned_table :foos3, type: :hash, key: :created_at do |t|
                   t.timestamps :null => false
                   t.text :text_column
                 end

--- a/spec/safe_statements_spec.rb
+++ b/spec/safe_statements_spec.rb
@@ -1056,11 +1056,11 @@ RSpec.describe PgHaMigrations::SafeStatements do
               migration.suppress_messages { migration.migrate(:up) }
 
               result = _select_enum_names_and_values
-              expect(result).to eq([
+              expect(result).to contain_exactly(
                 {"name" => "bt_foo_enum", "value" => "one"},
                 {"name" => "bt_foo_enum", "value" => "two"},
                 {"name" => "bt_foo_enum", "value" => "three"},
-              ])
+              )
             end
 
             it "can create a new enum type with symbols for values" do
@@ -1073,11 +1073,11 @@ RSpec.describe PgHaMigrations::SafeStatements do
               migration.suppress_messages { migration.migrate(:up) }
 
               result = _select_enum_names_and_values
-              expect(result).to eq([
+              expect(result).to contain_exactly(
                 {"name" => "bt_foo_enum", "value" => "one"},
                 {"name" => "bt_foo_enum", "value" => "two"},
                 {"name" => "bt_foo_enum", "value" => "three"},
-              ])
+              )
             end
 
             it "can create a new enum type with no values" do
@@ -1118,12 +1118,12 @@ RSpec.describe PgHaMigrations::SafeStatements do
               migration.suppress_messages { migration.migrate(:up) }
 
               result = _select_enum_names_and_values
-              expect(result).to eq([
+              expect(result).to contain_exactly(
                 {"name" => "bt_foo_enum", "value" => "one"},
                 {"name" => "bt_foo_enum", "value" => "two"},
                 {"name" => "bt_foo_enum", "value" => "three"},
                 {"name" => "bt_foo_enum", "value" => "four"},
-              ])
+              )
             end
           end
 
@@ -1140,11 +1140,11 @@ RSpec.describe PgHaMigrations::SafeStatements do
 
               migration.suppress_messages { migration.migrate(:up) }
 
-              expect(_select_enum_names_and_values).to match_array([
+              expect(_select_enum_names_and_values).to contain_exactly(
                 {"name" => "bt_foo_enum", "value" => "one"},
                 {"name" => "bt_foo_enum", "value" => "two"},
                 {"name" => "bt_foo_enum", "value" => "updated"},
-              ])
+              )
             end
 
             it "raises a helpful error on 9.6" do

--- a/spec/safe_statements_spec.rb
+++ b/spec/safe_statements_spec.rb
@@ -1814,7 +1814,7 @@ RSpec.describe PgHaMigrations::SafeStatements do
           end
 
           it "creates hash partition" do
-            skip "Only relevant on Postgres 10+" unless ActiveRecord::Base.connection.postgresql_version >= 10_00_00
+            skip "Only relevant on Postgres 11+" unless ActiveRecord::Base.connection.postgresql_version >= 11_00_00
 
             migration = Class.new(migration_klass) do
               def up

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,6 +26,7 @@ RSpec.configure do |config|
   end
 
   config.after(:each) do
+    # ActiveRecord::Base.connection.tables does not include partitioned tables in Rails 5.1
     ActiveRecord::Base.connection.select_values("SELECT tablename FROM pg_tables WHERE schemaname = 'public'").each do |table|
       ActiveRecord::Base.connection.execute("DROP TABLE #{table} CASCADE")
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,7 +26,7 @@ RSpec.configure do |config|
   end
 
   config.after(:each) do
-    ActiveRecord::Base.connection.tables.each do |table|
+    ActiveRecord::Base.connection.select_values("SELECT tablename FROM pg_tables WHERE schemaname = 'public'").each do |table|
       ActiveRecord::Base.connection.execute("DROP TABLE #{table} CASCADE")
     end
     ActiveRecord::Base.connection.select_values("SELECT typname FROM pg_type WHERE typtype = 'e'").each do |enum|


### PR DESCRIPTION
This adds a new migration method `safe_create_partition` for creating range, list, and hash partitioned tables. I haven't updated any docs yet, but if y'all like this approach I'll go ahead and do that. Once merged, I plan to follow up with additional PRs to implement pg_partman specific features as well as functionality to create, attach, and detach child partitions.