### PR TITLE
Don't unnecessarily use Exception in lieu of StandardError

### DIFF
--- a/lib/pg_ha_migrations.rb
+++ b/lib/pg_ha_migrations.rb
@@ -44,7 +44,7 @@ module PgHaMigrations
   # raise this error. For example, adding a column without a default and
   # then setting its default in a second action in a single migration
   # isn't our documented best practice and will raise this error.
-  BestPracticeError = Class.new(Exception)
+  BestPracticeError = Class.new(StandardError)
 
   # Unsupported migrations use ActiveRecord::Migration features that
   # we don't support, and therefore will likely have unexpected behavior.


### PR DESCRIPTION
Most exceptions (lowercase) in Ruby should inherit from `StandardError` rather than that class's ancestor of `Exception` (since `Exception` is often not something you should rescue).