### PR TITLE
Use Rails built-in {add,remove}_check_constraint

### DIFF
--- a/lib/pg_ha_migrations/safe_statements.rb
+++ b/lib/pg_ha_migrations/safe_statements.rb
@@ -170,20 +170,6 @@ module PgHaMigrations::SafeStatements
     unsafe_add_check_constraint(table, expression, name: name, validate: false)
   end
 
-  def unsafe_add_check_constraint(table, expression, name:, validate: true)
-    raise ArgumentError, "Expected <name> to be present" unless name.present?
-
-    quoted_table_name = connection.quote_table_name(table)
-    quoted_constraint_name = connection.quote_table_name(name)
-    sql = "ALTER TABLE #{quoted_table_name} ADD CONSTRAINT #{quoted_constraint_name} CHECK (#{expression}) #{validate ? "" : "NOT VALID"}"
-
-    safely_acquire_lock_for_table(table) do
-      say_with_time "add_check_constraint(#{table.inspect}, #{expression.inspect}, name: #{name.inspect}, validate: #{validate.inspect})" do
-        connection.execute(sql)
-      end
-    end
-  end
-
   def safe_validate_check_constraint(table, name:)
     raise ArgumentError, "Expected <name> to be present" unless name.present?
 

--- a/lib/pg_ha_migrations/unsafe_statements.rb
+++ b/lib/pg_ha_migrations/unsafe_statements.rb
@@ -45,6 +45,8 @@ module PgHaMigrations::UnsafeStatements
   delegate_unsafe_method_to_migration_base_class :remove_index
   delegate_unsafe_method_to_migration_base_class :add_foreign_key
   delegate_unsafe_method_to_migration_base_class :remove_foreign_key
+  delegate_unsafe_method_to_migration_base_class :add_check_constraint
+  delegate_unsafe_method_to_migration_base_class :remove_check_constraint
 
   disable_or_delegate_default_method :create_table, ":create_table is NOT SAFE! Use safe_create_table instead"
   disable_or_delegate_default_method :add_column, ":add_column is NOT SAFE! Use safe_add_column instead"
@@ -61,6 +63,8 @@ module PgHaMigrations::UnsafeStatements
   disable_or_delegate_default_method :remove_index, ":remove_index is NOT SAFE! Use safe_remove_concurrent_index instead for Postgres 9.6 databases; Explicitly call :unsafe_remove_index to proceed on Postgres 9.1"
   disable_or_delegate_default_method :add_foreign_key, ":add_foreign_key is NOT SAFE! Explicitly call :unsafe_add_foreign_key"
   disable_or_delegate_default_method :remove_foreign_key, ":remove_foreign_key is NOT SAFE! Explicitly call :unsafe_remove_foreign_key"
+  disable_or_delegate_default_method :add_check_constraint, ":add_check_constraint is NOT SAFE! Use :safe_add_unvalidated_check_constraint and then :safe_validate_check_constraint instead"
+  disable_or_delegate_default_method :remove_check_constraint, ":remove_check_constraint is NOT SAFE! Explicitly call :unsafe_remove_check_constraint to proceed"
 
   def unsafe_create_table(table, options={}, &block)
     if options[:force] && !PgHaMigrations.config.allow_force_create_table


### PR DESCRIPTION
When we initially added this I'm not sure these methods existed. Since they do now we should build on top of them as well as apply our standard method for preventing using the native methods directly without an `unsafe_` prefix.