### PR TITLE
Pin partman version for testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,6 @@ RUN apt-get update && apt-get install -y curl ca-certificates gnupg lsb-release
 
 RUN curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor | tee /etc/apt/trusted.gpg.d/apt.postgresql.org.gpg >/dev/null
 
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list
+RUN echo "deb https://apt-archive.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg-archive main" > /etc/apt/sources.list.d/pgdg.list
 
-RUN apt update && apt-get install -y postgresql-$PG_MAJOR-partman
+RUN apt update && apt-get install -y postgresql-$PG_MAJOR-partman=4.7.4-2.pgdg110+1

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The following functionality is currently unsupported:
 
 Compatibility notes:
 
-- While some features may work with older versions, this gem is currently tested against PostgreSQL 11+
+- While some features may work with other versions, this gem is currently tested against PostgreSQL 11+ and Partman 4.x
 - There is a [bug](https://github.com/rails/rails/pull/41490) in early versions of Rails 6.1 when using `algorithm: :concurrently`. To add / remove indexes concurrently, please upgrade to at least Rails 6.1.4.
 
 #### safe\_create\_table


### PR DESCRIPTION
Partman version 5 was just released which includes a lot of breaking changes. We should definitely investigate supporting it, but in the meantime let's pin to version 4 to get the tests passing.