### PR TITLE
Generate index names less than 63 bytes

### DIFF
--- a/lib/pg_ha_migrations/unsafe_statements.rb
+++ b/lib/pg_ha_migrations/unsafe_statements.rb
@@ -80,6 +80,16 @@ module PgHaMigrations::UnsafeStatements
       raise PgHaMigrations::InvalidMigrationError, "ActiveRecord drops the :opclass option when supplying a string containing an expression or list of columns; instead either supply an array of columns or include the opclass in the string for each column"
     end
 
+    validated_table = PgHaMigrations::Table.from_table_name(table)
+
+    validated_index = if options[:name]
+      PgHaMigrations::Index.new(options[:name], validated_table)
+    else
+      PgHaMigrations::Index.from_table_and_columns(validated_table, column_names)
+    end
+
+    options[:name] = validated_index.name
+
     execute_ancestor_statement(:add_index, table, column_names, **options)
   end
 

--- a/spec/safe_statements_spec.rb
+++ b/spec/safe_statements_spec.rb
@@ -1927,6 +1927,18 @@ RSpec.describe PgHaMigrations::SafeStatements do
               columns: ["bar"],
             )
           end
+
+          it "raises error when table does not exist" do
+            test_migration = Class.new(migration_klass) do
+              def up
+                unsafe_add_index :foo, :bar
+              end
+            end
+
+            expect do
+              test_migration.suppress_messages { test_migration.migrate(:up) }
+            end.to raise_error(PgHaMigrations::UndefinedTableError, "Table \"foo\" does not exist in search path")
+          end
         end
 
         describe "safe_remove_concurrent_index" do


### PR DESCRIPTION
This was previously in https://github.com/braintree/pg_ha_migrations/pull/86, but that only solved the problem for creating partitioned indexes. This more holistically addresses #89

Essentially backports [this feature](https://github.com/rails/rails/pull/47753) into older versions of Rails