### PR TITLE
Introduce raw methods for direct dispatch

### DIFF
--- a/lib/pg_ha_migrations.rb
+++ b/lib/pg_ha_migrations.rb
@@ -19,9 +19,9 @@ module PgHaMigrations
   def self.config
     @config ||= Config.new(
       true,
-      false,
       true,
       false,
+      true,
       true
     )
   end

--- a/lib/pg_ha_migrations/unsafe_statements.rb
+++ b/lib/pg_ha_migrations/unsafe_statements.rb
@@ -1,10 +1,6 @@
 module PgHaMigrations::UnsafeStatements
   def self.disable_or_delegate_default_method(method_name, error_message, allow_reentry_from_compatibility_module: false)
     define_method(method_name) do |*args, &block|
-      if PgHaMigrations.config.check_for_dependent_objects
-        disallow_migration_method_if_dependent_objects!(method_name, arguments: args)
-      end
-
       if PgHaMigrations.config.disable_default_migration_methods
         # Most migration methods are only ever called by a migration and
         # therefore aren't re-entrant or callable from another migration
@@ -12,7 +8,7 @@ module PgHaMigrations::UnsafeStatements
         # implementations in `ActiveRecord::Migration::Compatibility` so
         # we have to explicitly handle that case by allowing execution of
         # the original implementation by its original name.
-        unless  allow_reentry_from_compatibility_module && caller[0] =~ /lib\/active_record\/migration\/compatibility.rb/
+        unless allow_reentry_from_compatibility_module && caller[0] =~ /lib\/active_record\/migration\/compatibility.rb/
           raise PgHaMigrations::UnsafeMigrationError, error_message
         end
       end
@@ -33,38 +29,67 @@ module PgHaMigrations::UnsafeStatements
     ruby2_keywords "unsafe_#{method_name}"
   end
 
+  def self.delegate_raw_method_to_migration_base_class(method_name)
+    define_method("raw_#{method_name}") do |*args, &block|
+      execute_ancestor_statement(method_name, *args, &block)
+    end
+    ruby2_keywords "raw_#{method_name}"
+  end
+
+  # Direct dispatch to underlying Rails method as unsafe_<method_name> with dependent object check
+  delegate_unsafe_method_to_migration_base_class :add_check_constraint
   delegate_unsafe_method_to_migration_base_class :add_column
-  delegate_unsafe_method_to_migration_base_class :change_table
-  delegate_unsafe_method_to_migration_base_class :drop_table
-  delegate_unsafe_method_to_migration_base_class :rename_table
-  delegate_unsafe_method_to_migration_base_class :rename_column
+  delegate_unsafe_method_to_migration_base_class :add_foreign_key
   delegate_unsafe_method_to_migration_base_class :change_column
   delegate_unsafe_method_to_migration_base_class :change_column_default
-  delegate_unsafe_method_to_migration_base_class :remove_column
+  delegate_unsafe_method_to_migration_base_class :change_table
+  delegate_unsafe_method_to_migration_base_class :drop_table
   delegate_unsafe_method_to_migration_base_class :execute
-  delegate_unsafe_method_to_migration_base_class :remove_index
-  delegate_unsafe_method_to_migration_base_class :add_foreign_key
-  delegate_unsafe_method_to_migration_base_class :remove_foreign_key
-  delegate_unsafe_method_to_migration_base_class :add_check_constraint
   delegate_unsafe_method_to_migration_base_class :remove_check_constraint
+  delegate_unsafe_method_to_migration_base_class :remove_column
+  delegate_unsafe_method_to_migration_base_class :remove_foreign_key
+  delegate_unsafe_method_to_migration_base_class :remove_index
+  delegate_unsafe_method_to_migration_base_class :rename_column
+  delegate_unsafe_method_to_migration_base_class :rename_table
 
-  disable_or_delegate_default_method :create_table, ":create_table is NOT SAFE! Use safe_create_table instead"
+  # Direct dispatch to underlying Rails method as raw_<method_name> without dependent object check
+  delegate_raw_method_to_migration_base_class :add_check_constraint
+  delegate_raw_method_to_migration_base_class :add_column
+  delegate_raw_method_to_migration_base_class :add_foreign_key
+  delegate_raw_method_to_migration_base_class :add_index
+  delegate_raw_method_to_migration_base_class :change_column
+  delegate_raw_method_to_migration_base_class :change_column_default
+  delegate_raw_method_to_migration_base_class :change_column_null
+  delegate_raw_method_to_migration_base_class :change_table
+  delegate_raw_method_to_migration_base_class :create_table
+  delegate_raw_method_to_migration_base_class :drop_table
+  delegate_raw_method_to_migration_base_class :execute
+  delegate_raw_method_to_migration_base_class :remove_check_constraint
+  delegate_raw_method_to_migration_base_class :remove_column
+  delegate_raw_method_to_migration_base_class :remove_foreign_key
+  delegate_raw_method_to_migration_base_class :remove_index
+  delegate_raw_method_to_migration_base_class :rename_column
+  delegate_raw_method_to_migration_base_class :rename_table
+
+  # Raises error if disable_default_migration_methods is true
+  # Otherwise, direct dispatch to underlying Rails method without dependent object check
+  disable_or_delegate_default_method :add_check_constraint, ":add_check_constraint is NOT SAFE! Use :safe_add_unvalidated_check_constraint and then :safe_validate_check_constraint instead"
   disable_or_delegate_default_method :add_column, ":add_column is NOT SAFE! Use safe_add_column instead"
-  disable_or_delegate_default_method :change_table, ":change_table is NOT SAFE! Use a combination of safe and explicit unsafe migration methods instead"
-  disable_or_delegate_default_method :drop_table, ":drop_table is NOT SAFE! Explicitly call :unsafe_drop_table to proceed"
-  disable_or_delegate_default_method :rename_table, ":rename_table is NOT SAFE! Explicitly call :unsafe_rename_table to proceed"
-  disable_or_delegate_default_method :rename_column, ":rename_column is NOT SAFE! Explicitly call :unsafe_rename_column to proceed"
+  disable_or_delegate_default_method :add_foreign_key, ":add_foreign_key is NOT SAFE! Explicitly call :unsafe_add_foreign_key"
+  disable_or_delegate_default_method :add_index, ":add_index is NOT SAFE! Use safe_add_concurrent_index instead"
   disable_or_delegate_default_method :change_column, ":change_column is NOT SAFE! Use a combination of safe and explicit unsafe migration methods instead"
   disable_or_delegate_default_method :change_column_default, ":change_column_default is NOT SAFE! Use safe_change_column_default instead"
   disable_or_delegate_default_method :change_column_null, ":change_column_null is NOT (guaranteed to be) SAFE! Either use :safe_make_column_nullable or explicitly call :unsafe_make_column_not_nullable to proceed"
-  disable_or_delegate_default_method :remove_column, ":remove_column is NOT SAFE! Explicitly call :unsafe_remove_column to proceed"
-  disable_or_delegate_default_method :add_index, ":add_index is NOT SAFE! Use safe_add_concurrent_index instead"
+  disable_or_delegate_default_method :change_table, ":change_table is NOT SAFE! Use a combination of safe and explicit unsafe migration methods instead"
+  disable_or_delegate_default_method :create_table, ":create_table is NOT SAFE! Use safe_create_table instead"
+  disable_or_delegate_default_method :drop_table, ":drop_table is NOT SAFE! Explicitly call :unsafe_drop_table to proceed"
   disable_or_delegate_default_method :execute, ":execute is NOT SAFE! Explicitly call :unsafe_execute to proceed", allow_reentry_from_compatibility_module: true
-  disable_or_delegate_default_method :remove_index, ":remove_index is NOT SAFE! Use safe_remove_concurrent_index instead for Postgres 9.6 databases; Explicitly call :unsafe_remove_index to proceed on Postgres 9.1"
-  disable_or_delegate_default_method :add_foreign_key, ":add_foreign_key is NOT SAFE! Explicitly call :unsafe_add_foreign_key"
-  disable_or_delegate_default_method :remove_foreign_key, ":remove_foreign_key is NOT SAFE! Explicitly call :unsafe_remove_foreign_key"
-  disable_or_delegate_default_method :add_check_constraint, ":add_check_constraint is NOT SAFE! Use :safe_add_unvalidated_check_constraint and then :safe_validate_check_constraint instead"
   disable_or_delegate_default_method :remove_check_constraint, ":remove_check_constraint is NOT SAFE! Explicitly call :unsafe_remove_check_constraint to proceed"
+  disable_or_delegate_default_method :remove_column, ":remove_column is NOT SAFE! Explicitly call :unsafe_remove_column to proceed"
+  disable_or_delegate_default_method :remove_foreign_key, ":remove_foreign_key is NOT SAFE! Explicitly call :unsafe_remove_foreign_key"
+  disable_or_delegate_default_method :remove_index, ":remove_index is NOT SAFE! Use safe_remove_concurrent_index instead for Postgres 9.6 databases; Explicitly call :unsafe_remove_index to proceed on Postgres 9.1"
+  disable_or_delegate_default_method :rename_column, ":rename_column is NOT SAFE! Explicitly call :unsafe_rename_column to proceed"
+  disable_or_delegate_default_method :rename_table, ":rename_table is NOT SAFE! Explicitly call :unsafe_rename_table to proceed"
 
   def unsafe_create_table(table, options={}, &block)
     if options[:force] && !PgHaMigrations.config.allow_force_create_table

--- a/spec/dependent_object_checks_spec.rb
+++ b/spec/dependent_object_checks_spec.rb
@@ -44,17 +44,11 @@ RSpec.describe PgHaMigrations::UnsafeStatements do
         end
       end
 
-      [true, false].each do |disable_default_migration_methods|
-        describe "disable_default_migration_methods = #{disable_default_migration_methods}" do
-          method_prefix = disable_default_migration_methods ? "unsafe_" : ""
-
+      ["", "raw_"].each do |method_prefix|
+        describe "#{method_prefix.empty? ? "standard rails" : "raw"} methods" do
           before(:each) do
             allow(PgHaMigrations.config).to receive(:disable_default_migration_methods)
-              .and_return(disable_default_migration_methods)
-
-            # The default behavior until 2.0 is to disable this feature, but it's a lot easier
-            # to write most of these tests if we default to enabled here instead.
-            allow(PgHaMigrations.config).to receive(:check_for_dependent_objects).and_return(true)
+              .and_return(false)
           end
 
           describe "##{method_prefix}remove_column" do
@@ -77,48 +71,101 @@ RSpec.describe PgHaMigrations::UnsafeStatements do
               setup_migration.suppress_messages { setup_migration.migrate(:up) }
             end
 
-            it "raises when dependent indexes exist" do
+            it "does not raise and drops dependent indexes" do
               migration = Class.new(migration_klass) do
                 def up
                   public_send(remove_column_method_name, :foos3, :text_column)
                 end
               end
 
-              expect do
-                migration.suppress_messages { migration.migrate(:up) }
-              end.to raise_error(PgHaMigrations::UnsafeMigrationError, /index 'index_foos3_on_text_column' depends on column 'text_column'/)
-
-              # We can't drop the index _before_ raising the error :D
               indexes = ActiveRecord::Base.connection.indexes("foos3")
               expect(indexes.size).to eq(1)
               expect(indexes).to all(have_attributes(:table => "foos3", :name => "index_foos3_on_text_column", :columns => ["text_column"]))
-            end
 
-            it "ignores dependent indexes when explicitly allowed" do
-              migration = Class.new(migration_klass) do
-                def up
-                  public_send(remove_column_method_name, :foos3, :text_column, :allow_dependent_objects => [:indexes])
-                end
-              end
-
-              migration.suppress_messages { migration.migrate(:up) }
+              expect do
+                migration.suppress_messages { migration.migrate(:up) }
+              end.to_not raise_error
 
               expect(ActiveRecord::Base.connection.columns("foos3").map(&:name)).not_to include("text_column")
+              indexes = ActiveRecord::Base.connection.indexes("foos3")
+              expect(indexes).to be_empty
             end
+          end
+        end
+      end
 
-            it "ignores dependent indexes when dependent object checks are disabled" do
-              allow(PgHaMigrations.config).to receive(:check_for_dependent_objects).and_return(false)
-
-              migration = Class.new(migration_klass) do
-                def up
-                  public_send(remove_column_method_name, :foos3, :text_column)
+      describe "unsafe methods" do
+        describe "#unsafe_remove_column" do
+          before(:each) do
+            setup_migration = Class.new(migration_klass) do
+              def up
+                safe_create_table :foos3 do |t|
+                  t.timestamps :null => false
+                  t.text :text_column
                 end
+                safe_add_concurrent_index :foos3, :text_column
               end
-
-              migration.suppress_messages { migration.migrate(:up) }
-
-              expect(ActiveRecord::Base.connection.columns("foos3").map(&:name)).not_to include("text_column")
             end
+
+            setup_migration.suppress_messages { setup_migration.migrate(:up) }
+          end
+
+          it "raises when dependent indexes exist" do
+            migration = Class.new(migration_klass) do
+              def up
+                unsafe_remove_column :foos3, :text_column
+              end
+            end
+
+            indexes = ActiveRecord::Base.connection.indexes("foos3")
+            expect(indexes.size).to eq(1)
+            expect(indexes).to all(have_attributes(:table => "foos3", :name => "index_foos3_on_text_column", :columns => ["text_column"]))
+
+            expect do
+              migration.suppress_messages { migration.migrate(:up) }
+            end.to raise_error(PgHaMigrations::UnsafeMigrationError, /index 'index_foos3_on_text_column' depends on column 'text_column'/)
+
+            indexes = ActiveRecord::Base.connection.indexes("foos3")
+            expect(indexes.size).to eq(1)
+            expect(indexes).to all(have_attributes(:table => "foos3", :name => "index_foos3_on_text_column", :columns => ["text_column"]))
+          end
+
+          it "ignores dependent indexes when explicitly allowed" do
+            migration = Class.new(migration_klass) do
+              def up
+                unsafe_remove_column :foos3, :text_column, :allow_dependent_objects => [:indexes]
+              end
+            end
+
+            indexes = ActiveRecord::Base.connection.indexes("foos3")
+            expect(indexes.size).to eq(1)
+            expect(indexes).to all(have_attributes(:table => "foos3", :name => "index_foos3_on_text_column", :columns => ["text_column"]))
+
+            migration.suppress_messages { migration.migrate(:up) }
+
+            expect(ActiveRecord::Base.connection.columns("foos3").map(&:name)).not_to include("text_column")
+            indexes = ActiveRecord::Base.connection.indexes("foos3")
+            expect(indexes).to be_empty
+          end
+
+          it "ignores dependent indexes when dependent object checks are disabled" do
+            allow(PgHaMigrations.config).to receive(:check_for_dependent_objects).and_return(false)
+
+            migration = Class.new(migration_klass) do
+              def up
+                unsafe_remove_column :foos3, :text_column
+              end
+            end
+
+            indexes = ActiveRecord::Base.connection.indexes("foos3")
+            expect(indexes.size).to eq(1)
+            expect(indexes).to all(have_attributes(:table => "foos3", :name => "index_foos3_on_text_column", :columns => ["text_column"]))
+
+            migration.suppress_messages { migration.migrate(:up) }
+
+            expect(ActiveRecord::Base.connection.columns("foos3").map(&:name)).not_to include("text_column")
+            indexes = ActiveRecord::Base.connection.indexes("foos3")
+            expect(indexes).to be_empty
           end
         end
       end

--- a/spec/pg_ha_migrations_spec.rb
+++ b/spec/pg_ha_migrations_spec.rb
@@ -29,44 +29,44 @@ RSpec.describe PgHaMigrations do
     end
 
     context "check_for_dependent_objects" do
-      it "is set to false by default" do
-        expect(PgHaMigrations.config.check_for_dependent_objects).to be(false)
-      end
-
-      it "can be overriden to true" do
-        PgHaMigrations.configure do |config|
-          config.check_for_dependent_objects = true
-        end
-
-        expect(PgHaMigrations.config.check_for_dependent_objects).to be(true)
-      end
-    end
-
-    context "allow_force_create_table" do
       it "is set to true by default" do
-        expect(PgHaMigrations.config.allow_force_create_table).to be(true)
+        expect(PgHaMigrations.config.check_for_dependent_objects).to be(true)
       end
 
       it "can be overriden to false" do
         PgHaMigrations.configure do |config|
-          config.allow_force_create_table = false
+          config.check_for_dependent_objects = false
         end
 
-        expect(PgHaMigrations.config.allow_force_create_table).to be(false)
+        expect(PgHaMigrations.config.check_for_dependent_objects).to be(false)
       end
     end
 
-    context "prefer_single_step_column_addition_with_default" do
+    context "allow_force_create_table" do
       it "is set to false by default" do
-        expect(PgHaMigrations.config.prefer_single_step_column_addition_with_default).to be(false)
+        expect(PgHaMigrations.config.allow_force_create_table).to be(false)
       end
 
       it "can be overriden to true" do
         PgHaMigrations.configure do |config|
-          config.prefer_single_step_column_addition_with_default = true
+          config.allow_force_create_table = true
         end
 
+        expect(PgHaMigrations.config.allow_force_create_table).to be(true)
+      end
+    end
+
+    context "prefer_single_step_column_addition_with_default" do
+      it "is set to true by default" do
         expect(PgHaMigrations.config.prefer_single_step_column_addition_with_default).to be(true)
+      end
+
+      it "can be overriden to false" do
+        PgHaMigrations.configure do |config|
+          config.prefer_single_step_column_addition_with_default = false
+        end
+
+        expect(PgHaMigrations.config.prefer_single_step_column_addition_with_default).to be(false)
       end
     end
 


### PR DESCRIPTION
I view this as the first step to addressing #63 

- raw_* methods added, and are direct dispatch to Rails
- standard Rails methods changed (when `disable_default_migration_methods` is `false`), and are now direct dispatch to Rails
- default config values changed in preparation for 2.0 release