### PR TITLE
Safely acquire lock on multiple tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,7 +451,7 @@ safe_partman_reapply_privileges :table
 
 #### safely\_acquire\_lock\_for\_table
 
-Acquires a lock on a table using the following algorithm:
+Acquires a lock (in `ACCESS EXCLUSIVE` mode by default) on a table using the following algorithm:
 
 1. Verify that no long-running queries are using the table.
     - If long-running queries are currently using the table, sleep `PgHaMigrations::LOCK_TIMEOUT_SECONDS` and check again.
@@ -459,15 +459,13 @@ Acquires a lock on a table using the following algorithm:
     - If the lock is not acquired, sleep `PgHaMigrations::LOCK_FAILURE_RETRY_DELAY_MULTLIPLIER * PgHaMigrations::LOCK_TIMEOUT_SECONDS`, and start again at step 1.
 3. If the lock is acquired, proceed to run the given block.
 
-Safely acquire an access exclusive lock for a table.
-
 ```ruby
 safely_acquire_lock_for_table(:table) do
   ...
 end
 ```
 
-Safely acquire a lock for a table in a different mode.
+Safely acquire a lock on a table in `SHARE` mode.
 
 ```ruby
 safely_acquire_lock_for_table(:table, mode: :share) do
@@ -475,10 +473,18 @@ safely_acquire_lock_for_table(:table, mode: :share) do
 end
 ```
 
+Safely acquire a lock on multiple tables in `EXCLUSIVE` mode.
+
+```ruby
+safely_acquire_lock_for_table(:table_a, :table_b, mode: :exclusive) do
+  ...
+end
+```
+
 Note:
 
-We enforce that only one table (or a table and its partitions) can be locked at a time.
-Attempting to acquire a nested lock on a different table will result in an error.
+We enforce that only one set of tables can be locked at a time.
+Attempting to acquire a nested lock on a different set of tables will result in an error.
 
 #### adjust\_lock\_timeout
 

--- a/lib/pg_ha_migrations/lock_mode.rb
+++ b/lib/pg_ha_migrations/lock_mode.rb
@@ -93,6 +93,14 @@ module PgHaMigrations
       MODE_CONFLICTS.keys.index(mode) <=> MODE_CONFLICTS.keys.index(other.mode)
     end
 
+    def eql?(other)
+      mode == other.mode
+    end
+
+    def hash
+      mode.hash
+    end
+
     def conflicts_with?(other)
       MODE_CONFLICTS[mode].include?(other.mode)
     end

--- a/lib/pg_ha_migrations/lock_mode.rb
+++ b/lib/pg_ha_migrations/lock_mode.rb
@@ -94,7 +94,11 @@ module PgHaMigrations
     end
 
     def eql?(other)
-      mode == other.mode
+      other.is_a?(LockMode) && mode == other.mode
+    end
+
+    def ==(other)
+      eql?(other)
     end
 
     def hash

--- a/lib/pg_ha_migrations/relation.rb
+++ b/lib/pg_ha_migrations/relation.rb
@@ -185,7 +185,7 @@ module PgHaMigrations
     attr_reader :raw_set
 
     delegate :each, to: :raw_set
-    delegate :mode, to: :first, allow_nil: true
+    delegate :mode, to: :first
 
     def self.from_table_names(tables, mode=nil)
       new(tables) { |table| Table.from_table_name(table, mode) }
@@ -193,6 +193,14 @@ module PgHaMigrations
 
     def initialize(tables, &blk)
       @raw_set = tables.map(&blk).to_set
+
+      if raw_set.empty?
+        raise ArgumentError, "Expected a non-empty list of tables"
+      end
+
+      if raw_set.uniq(&:mode).size > 1
+        raise ArgumentError, "Expected all tables in collection to have the same lock mode"
+      end
     end
 
     def subset?(other)

--- a/lib/pg_ha_migrations/relation.rb
+++ b/lib/pg_ha_migrations/relation.rb
@@ -29,7 +29,7 @@ module PgHaMigrations
     end
 
     def conflicts_with?(other)
-      self.eql?(other) && (
+      eql?(other) && (
         mode.nil? || other.mode.nil? || mode.conflicts_with?(other.mode)
       )
     end
@@ -40,6 +40,10 @@ module PgHaMigrations
     # To also compare lock modes, #conflicts_with? is used.
     def eql?(other)
       other.is_a?(Relation) && hash == other.hash
+    end
+
+    def ==(other)
+      eql?(other)
     end
 
     def hash

--- a/lib/pg_ha_migrations/relation.rb
+++ b/lib/pg_ha_migrations/relation.rb
@@ -171,13 +171,24 @@ module PgHaMigrations
     end
   end
 
-  class TableCollection < Set
+  class TableCollection
+    include Enumerable
+
+    attr_reader :raw_set
+
+    delegate :each, to: :raw_set
+    delegate :mode, to: :first, allow_nil: true
+
     def self.from_table_names(tables, mode=nil)
       new(tables) { |table| Table.from_table_name(table, mode) }
     end
 
-    def mode
-      first&.mode
+    def initialize(tables, &blk)
+      @raw_set = tables.map(&blk).to_set
+    end
+
+    def subset?(other)
+      raw_set.subset?(other.raw_set)
     end
 
     def to_sql

--- a/lib/pg_ha_migrations/safe_statements.rb
+++ b/lib/pg_ha_migrations/safe_statements.rb
@@ -598,6 +598,9 @@ module PgHaMigrations::SafeStatements
 
       connection.transaction do
         begin
+          # A lock timeout would apply to each individual table in the query,
+          # so we made a conscious decision to use a statement timeout here
+          # to keep behavior consistent in a multi-table lock scenario.
           adjust_statement_timeout(PgHaMigrations::LOCK_TIMEOUT_SECONDS) do
             connection.execute("LOCK #{target_tables.to_sql} IN #{target_tables.mode.to_sql} MODE;")
           end

--- a/spec/safe_statements_spec.rb
+++ b/spec/safe_statements_spec.rb
@@ -4428,11 +4428,20 @@ RSpec.describe PgHaMigrations::SafeStatements do
             alternate_connection_pool.connection
           end
         end
+        let(:alternate_connection_2) do
+          # The #connection method was deprecated in Rails 7.2 in favor of #lease_connection
+          if alternate_connection_pool.respond_to?(:lease_connection)
+            alternate_connection_pool.lease_connection
+          else
+            alternate_connection_pool.connection
+          end
+        end
         let(:migration) { Class.new(migration_klass).new }
 
         before(:each) do
           ActiveRecord::Base.connection.execute(<<~SQL)
             CREATE TABLE #{table_name}(pk SERIAL, i INTEGER);
+            CREATE TABLE #{table_name}_2(pk SERIAL, i INTEGER);
             CREATE SCHEMA partman;
             CREATE EXTENSION pg_partman SCHEMA partman;
           SQL
@@ -4461,12 +4470,56 @@ RSpec.describe PgHaMigrations::SafeStatements do
           end
         end
 
+        it "acquires exclusive locks by default when multiple tables provided" do
+          migration.safely_acquire_lock_for_table(table_name, "bogus_table_2") do
+            expect(locks_for_table(table_name, connection: alternate_connection)).to contain_exactly(
+              having_attributes(
+                table: "bogus_table",
+                lock_type: "AccessExclusiveLock",
+                granted: true,
+                pid: kind_of(Integer),
+              )
+            )
+
+            expect(locks_for_table("bogus_table_2", connection: alternate_connection)).to contain_exactly(
+              having_attributes(
+                table: "bogus_table_2",
+                lock_type: "AccessExclusiveLock",
+                granted: true,
+                pid: kind_of(Integer),
+              )
+            )
+          end
+        end
+
         it "acquires a lock in a different mode when provided" do
           migration.safely_acquire_lock_for_table(table_name, mode: :share) do
             expect(locks_for_table(table_name, connection: alternate_connection)).to contain_exactly(
               having_attributes(
                 table: "bogus_table",
                 lock_type: "ShareLock",
+                granted: true,
+                pid: kind_of(Integer),
+              )
+            )
+          end
+        end
+
+        it "acquires locks in a different mode when multiple tables and mode provided" do
+          migration.safely_acquire_lock_for_table(table_name, "bogus_table_2", mode: :share_row_exclusive) do
+            expect(locks_for_table(table_name, connection: alternate_connection)).to contain_exactly(
+              having_attributes(
+                table: "bogus_table",
+                lock_type: "ShareRowExclusiveLock",
+                granted: true,
+                pid: kind_of(Integer),
+              )
+            )
+
+            expect(locks_for_table("bogus_table_2", connection: alternate_connection)).to contain_exactly(
+              having_attributes(
+                table: "bogus_table_2",
+                lock_type: "ShareRowExclusiveLock",
                 granted: true,
                 pid: kind_of(Integer),
               )
@@ -4512,6 +4565,39 @@ RSpec.describe PgHaMigrations::SafeStatements do
             migration.safely_acquire_lock_for_table(table_name) do
               expect(locks_for_table(table_name, connection: alternate_connection)).not_to be_empty
             end
+          end
+        end
+
+        it "times out the lock query after LOCK_TIMEOUT_SECONDS when multiple tables provided" do
+          stub_const("PgHaMigrations::LOCK_TIMEOUT_SECONDS", 1)
+          stub_const("PgHaMigrations::LOCK_FAILURE_RETRY_DELAY_MULTLIPLIER", 0)
+          allow(PgHaMigrations::BlockingDatabaseTransactions).to receive(:find_blocking_transactions).and_return([])
+          allow(ActiveRecord::Base.connection).to receive(:execute).and_call_original
+
+          expect(ActiveRecord::Base.connection).to receive(:execute)
+            .with("LOCK \"public\".\"bogus_table\", \"public\".\"bogus_table_2\" IN ACCESS EXCLUSIVE MODE;")
+            .at_least(2)
+            .times
+
+          begin
+            query_thread = Thread.new do
+              alternate_connection.execute("BEGIN; LOCK bogus_table_2;")
+              sleep 3
+              alternate_connection.execute("ROLLBACK")
+            end
+
+            sleep 0.5
+
+            migration.suppress_messages do
+              migration.safely_acquire_lock_for_table(table_name, "bogus_table_2") do
+                aggregate_failures do
+                  expect(locks_for_table(table_name, connection: alternate_connection_2)).not_to be_empty
+                  expect(locks_for_table("bogus_table_2", connection: alternate_connection_2)).not_to be_empty
+                end
+              end
+            end
+          ensure
+            query_thread.join
           end
         end
 
@@ -4935,6 +5021,121 @@ RSpec.describe PgHaMigrations::SafeStatements do
           expect(locks_for_table(table_name, connection: alternate_connection)).to be_empty
         end
 
+        it "allows re-entrancy when multiple tables provided" do
+          migration.safely_acquire_lock_for_table(table_name, "bogus_table_2") do
+            # The ordering of the args is intentional here to ensure
+            # the array sorting and equality logic works as intended
+            migration.safely_acquire_lock_for_table("bogus_table_2", table_name) do
+              expect(locks_for_table(table_name, connection: alternate_connection)).to contain_exactly(
+                having_attributes(
+                  table: "bogus_table",
+                  lock_type: "AccessExclusiveLock",
+                  granted: true,
+                  pid: kind_of(Integer),
+                ),
+              )
+
+              expect(locks_for_table("bogus_table_2", connection: alternate_connection)).to contain_exactly(
+                having_attributes(
+                  table: "bogus_table_2",
+                  lock_type: "AccessExclusiveLock",
+                  granted: true,
+                  pid: kind_of(Integer),
+                ),
+              )
+            end
+
+            expect(locks_for_table(table_name, connection: alternate_connection)).to contain_exactly(
+              having_attributes(
+                table: "bogus_table",
+                lock_type: "AccessExclusiveLock",
+                granted: true,
+                pid: kind_of(Integer),
+              ),
+            )
+
+            expect(locks_for_table("bogus_table_2", connection: alternate_connection)).to contain_exactly(
+              having_attributes(
+                table: "bogus_table_2",
+                lock_type: "AccessExclusiveLock",
+                granted: true,
+                pid: kind_of(Integer),
+              ),
+            )
+          end
+
+          expect(locks_for_table(table_name, connection: alternate_connection)).to be_empty
+          expect(locks_for_table("bogus_table_2", connection: alternate_connection)).to be_empty
+        end
+
+        it "allows re-entrancy when multiple tables provided and nested lock targets a subset of tables" do
+          migration.safely_acquire_lock_for_table(table_name, "bogus_table_2") do
+            migration.safely_acquire_lock_for_table(table_name) do
+              expect(locks_for_table(table_name, connection: alternate_connection)).to contain_exactly(
+                having_attributes(
+                  table: "bogus_table",
+                  lock_type: "AccessExclusiveLock",
+                  granted: true,
+                  pid: kind_of(Integer),
+                ),
+              )
+
+              expect(locks_for_table("bogus_table_2", connection: alternate_connection)).to contain_exactly(
+                having_attributes(
+                  table: "bogus_table_2",
+                  lock_type: "AccessExclusiveLock",
+                  granted: true,
+                  pid: kind_of(Integer),
+                ),
+              )
+            end
+
+            expect(locks_for_table(table_name, connection: alternate_connection)).to contain_exactly(
+              having_attributes(
+                table: "bogus_table",
+                lock_type: "AccessExclusiveLock",
+                granted: true,
+                pid: kind_of(Integer),
+              ),
+            )
+
+            expect(locks_for_table("bogus_table_2", connection: alternate_connection)).to contain_exactly(
+              having_attributes(
+                table: "bogus_table_2",
+                lock_type: "AccessExclusiveLock",
+                granted: true,
+                pid: kind_of(Integer),
+              ),
+            )
+          end
+
+          expect(locks_for_table(table_name, connection: alternate_connection)).to be_empty
+          expect(locks_for_table("bogus_table_2", connection: alternate_connection)).to be_empty
+        end
+
+        it "does not allow re-entrancy when multiple tables provided and nested lock targets a superset of tables" do
+          expect do
+            migration.safely_acquire_lock_for_table(table_name) do
+              expect(locks_for_table(table_name, connection: alternate_connection)).to contain_exactly(
+                having_attributes(
+                  table: "bogus_table",
+                  lock_type: "AccessExclusiveLock",
+                  granted: true,
+                  pid: kind_of(Integer),
+                ),
+              )
+
+              migration.safely_acquire_lock_for_table(table_name, "bogus_table_2") {}
+            end
+          end.to raise_error(
+            PgHaMigrations::InvalidMigrationError,
+            "Nested lock detected! Cannot acquire lock on \"public\".\"bogus_table\", \"public\".\"bogus_table_2\" while \"public\".\"bogus_table\" is locked."
+          )
+
+          expect(locks_for_table(table_name, connection: alternate_connection)).to be_empty
+          expect(locks_for_table("bogus_table_2", connection: alternate_connection)).to be_empty
+        end
+
         it "allows re-entrancy when inner lock is a lower level" do
           migration.safely_acquire_lock_for_table(table_name) do
             migration.safely_acquire_lock_for_table(table_name, mode: :exclusive) do
@@ -5036,26 +5237,6 @@ RSpec.describe PgHaMigrations::SafeStatements do
           )
 
           expect(locks_for_table(table_name, connection: alternate_connection)).to be_empty
-        end
-
-        it "uses statement_timeout instead of lock_timeout when on Postgres 9.1" do
-          allow(ActiveRecord::Base.connection).to receive(:postgresql_version).and_wrap_original do |m, *args|
-            if caller.detect { |line| line =~ /lib\/pg_ha_migrations\/blocking_database_transactions\.rb/ }
-              # The long-running transactions check needs to know the actual
-              # Postgres version to use the proper columns, so we don't want
-              # to mock any calls from it.
-              m.call(*args)
-            else
-              9_01_12
-            end
-          end
-
-          expect do
-            migration.safely_acquire_lock_for_table(table_name) do
-              expect(locks_for_table(table_name, connection: alternate_connection)).not_to be_empty
-            end
-            expect(locks_for_table(table_name, connection: alternate_connection)).to be_empty
-          end.not_to make_database_queries(matching: /lock_timeout/i)
         end
       end
     end

--- a/spec/table_collection_spec.rb
+++ b/spec/table_collection_spec.rb
@@ -1,0 +1,116 @@
+require "spec_helper"
+
+RSpec.describe PgHaMigrations::TableCollection do
+  let(:table_a) { PgHaMigrations::Table.new("a", "public") }
+  let(:table_b) { PgHaMigrations::Table.new("b", "public") }
+  let(:table_c) { PgHaMigrations::Table.new("c", "public", :exclusive) }
+  let(:table_d) { PgHaMigrations::Table.new("d", "public", :exclusive) }
+  let(:table_e) { PgHaMigrations::Table.new("e", "public", :access_exclusive) }
+
+  describe ".from_table_names" do
+    it "initializes a collection from table names" do
+      %w[a b].each do |table|
+        ActiveRecord::Base.connection.execute("CREATE TABLE #{table}(pk SERIAL)")
+      end
+
+      expect(described_class.from_table_names(["a", "b"])).to contain_exactly(table_a, table_b)
+    end
+
+    it "initializes a collection from table names and lock mode" do
+      %w[c d].each do |table|
+        ActiveRecord::Base.connection.execute("CREATE TABLE #{table}(pk SERIAL)")
+      end
+
+      expect(described_class.from_table_names(["c", "d"], :exclusive)).to contain_exactly(table_c, table_d)
+    end
+  end
+
+  describe ".new" do
+    it "initializes single item collection" do
+      expect(described_class.new([table_a])).to contain_exactly(table_a)
+    end
+
+    it "initializes multi-element collection" do
+      expect(described_class.new([table_a, table_b])).to contain_exactly(table_a, table_b)
+    end
+
+    it "initializes multi-element collection with lock modes" do
+      expect(described_class.new([table_c, table_d])).to contain_exactly(table_c, table_d)
+    end
+
+    it "initializes multi-element collection without duplicates" do
+      expect(described_class.new([table_a, table_a, table_b])).to contain_exactly(table_a, table_b)
+    end
+
+    it "raises error if collection is empty" do
+      expect do
+        described_class.new([])
+      end.to raise_error(ArgumentError, "Expected a non-empty list of tables")
+    end
+
+    it "raises error if collection contains a mix of nil and non-nil lock modes" do
+      expect do
+        described_class.new([table_a, table_c])
+      end.to raise_error(ArgumentError, "Expected all tables in collection to have the same lock mode")
+    end
+
+    it "raises error if collection contains a mix of different non-nil lock modes" do
+      expect do
+        described_class.new([table_d, table_e])
+      end.to raise_error(ArgumentError, "Expected all tables in collection to have the same lock mode")
+    end
+  end
+
+  describe "#subset?" do
+    it "returns true when collections are the same" do
+      source = described_class.new([table_a, table_b])
+      target = described_class.new([table_a, table_b])
+
+      expect(source.subset?(target)).to eq(true)
+    end
+
+    it "returns true when source contains some elements in the target" do
+      source = described_class.new([table_a])
+      target = described_class.new([table_a, table_b])
+
+      expect(source.subset?(target)).to eq(true)
+    end
+
+    it "returns false when source contains an element that the target does not have" do
+      source = described_class.new([table_a, table_b])
+      target = described_class.new([table_a])
+
+      expect(source.subset?(target)).to eq(false)
+    end
+  end
+
+  describe "#to_sql" do
+    it "returns the fully qualified name of the table in a single element collection" do
+      expect(described_class.new([table_a]).to_sql).to eq("\"public\".\"a\"")
+    end
+
+    it "returns a comma separated list of fully qualified names in a multi-element collection" do
+      expect(described_class.new([table_a, table_b]).to_sql).to eq("\"public\".\"a\", \"public\".\"b\"")
+    end
+  end
+
+  describe "#with_partitions" do
+    let(:table_c_part) { PgHaMigrations::Table.new("c_part", "public", :exclusive) }
+    let(:table_d_part) { PgHaMigrations::Table.new("d_part", "public", :exclusive) }
+
+    it "initializes an identical collection if no partitions present" do
+      expect(described_class.new([table_c, table_d]).with_partitions).to contain_exactly(table_c, table_d)
+    end
+
+    it "initializes a new collection with parent tables and child partitions when present" do
+      %w[c d].each do |table|
+        ActiveRecord::Base.connection.execute(<<~SQL)
+          CREATE TABLE #{table}(pk SERIAL) PARTITION BY RANGE (pk);
+          CREATE TABLE #{table}_part PARTITION OF #{table} FOR VALUES FROM (1) TO (2);
+        SQL
+      end
+
+      expect(described_class.new([table_c, table_d]).with_partitions).to contain_exactly(table_c, table_c_part, table_d, table_d_part)
+    end
+  end
+end


### PR DESCRIPTION
This functionality will allow us to improve the safety of operations that take out locks on multiple tables (e.g. adding / removing foreign keys).

I also discovered a bug in the nested lock acquisition logic, so this PR fixes that and adds more tests.

I feel like it's tradition at this point for me to include too many changes in a PR and for @jcoleman to ask me to break it up into smaller commits 😆 (~~I will try to do that tomorrow~~ done).