### PR TITLE
Add tests to verify the behavior of disable_ddl_transaction

### DIFF
--- a/spec/pg_ha_migrations_spec.rb
+++ b/spec/pg_ha_migrations_spec.rb
@@ -182,7 +182,10 @@ RSpec.describe PgHaMigrations do
           # Because our method now lives outside of the inheritance
           # hierarchy we can go back to using RSpec's method mocking.
           expect(ActiveRecord::Base.connection).to receive(:pg_ha_migrations_test_method).and_return("sentinel_value")
-          expect(subclass.new.unsafe_pg_ha_migrations_test_method).to eq("sentinel_value")
+
+          subclass.suppress_messages do
+            expect(subclass.new.unsafe_pg_ha_migrations_test_method).to eq("sentinel_value")
+          end
         end
       end
     end


### PR DESCRIPTION
With recent PRs / conversations around transactional migrations, I figured it would be a good idea to write some basic tests to verify existing behavior. In other tests, we execute test migrations directly which bypasses the transaction logic in AR.