### PR TITLE
Bug Fix for `unsafe_remove_check_constraint` in certain Rails version 

### DIFF
--- a/lib/pg_ha_migrations/safe_statements.rb
+++ b/lib/pg_ha_migrations/safe_statements.rb
@@ -598,6 +598,12 @@ module PgHaMigrations::SafeStatements
     Thread.current[__method__] = nil unless nested_target_table
   end
 
+  # since rails versions < 7.1 has bug which does not handle symbol for
+  # constraint name, we are converting name to string explicitly to solve that.
+  def raw_remove_check_constraint(table, name:, **options)
+    super(table, name: name.to_s, **options)
+  end
+
   def adjust_lock_timeout(timeout_seconds = PgHaMigrations::LOCK_TIMEOUT_SECONDS, &block)
     _check_postgres_adapter!
     original_timeout = ActiveRecord::Base.value_from_sql("SHOW lock_timeout").sub(/s\Z/, '').to_i * 1000


### PR DESCRIPTION
We identified that for certain rails version ( 6.1+, 7.0 ) , when we use symbol for constraint name, migration fails :
```
> -- remove_check_constraint("test_models", {:name=>:constraint_check_on_test_int_foo})
ArgumentError: Table 'test_models' has no check constraint for {:name=>:constraint_check_on_test_int_foo}
```

the bug is in this code path :
https://github.com/rails/rails/blob/16d8b82d5e2aca4780c5d10b1fe9a90b33a0e84e/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb#L1772-L1773

Note: this bug has been fixed in rails 7.1

This PR mainly overriding `unsafe_remove_check_constraint` method and converts `name` arg to `name.to_s`