### PR TITLE
Add support for Rails 8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,13 +10,13 @@ jobs:
           - 15
           - 16
         ruby:
-          - "3.1"
           - "3.2"
           - "3.3"
         gemfile:
           - rails_7.0
           - rails_7.1
           - rails_7.2
+          - rails_8.0
     name: PostgreSQL ${{ matrix.pg }} - Ruby ${{ matrix.ruby }} - ${{ matrix.gemfile }}
     runs-on: ubuntu-latest
     env: # $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps

--- a/Appraisals
+++ b/Appraisals
@@ -1,11 +1,15 @@
 appraise "rails-7.0" do
-  gem "rails", "7.0.8"
+  gem "rails", "~> 7.0.0"
 end
 
 appraise "rails-7.1" do
-  gem "rails", "7.1.5"
+  gem "rails", "~> 7.1.0"
 end
 
 appraise "rails-7.2" do
-  gem "rails", "7.2.2"
+  gem "rails", "~> 7.2.0"
+end
+
+appraise "rails-8.0" do
+  gem "rails", "~> 8.0.0"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,3 @@ git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
 # Specify your gem's dependencies in pg_ha_migrations.gemspec
 gemspec
-

--- a/gemfiles/rails_7.0.gemfile
+++ b/gemfiles/rails_7.0.gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "rails", "7.0.8"
+gem "rails", "~> 7.0.0"
 
 gemspec path: "../"

--- a/gemfiles/rails_7.2.gemfile
+++ b/gemfiles/rails_7.2.gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "rails", "7.2.2"
+gem "rails", "~> 7.2.0"
 
 gemspec path: "../"

--- a/gemfiles/rails_8.0.gemfile
+++ b/gemfiles/rails_8.0.gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 7.1.0"
+gem "rails", "~> 8.0.0"
 
 gemspec path: "../"

--- a/lib/pg_ha_migrations/allowed_versions.rb
+++ b/lib/pg_ha_migrations/allowed_versions.rb
@@ -1,7 +1,7 @@
 require "active_record/migration/compatibility"
 
 module PgHaMigrations::AllowedVersions
-  ALLOWED_VERSIONS = [4.2, 5.0, 5.1, 5.2, 6.0, 6.1, 7.0, 7.1, 7.2].map do |v|
+  ALLOWED_VERSIONS = [4.2, 5.0, 5.1, 5.2, 6.0, 6.1, 7.0, 7.1, 7.2, 8.0].map do |v|
     begin
       ActiveRecord::Migration[v]
     rescue ArgumentError

--- a/pg_ha_migrations.gemspec
+++ b/pg_ha_migrations.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "appraisal", "~> 2.5"
 
-  spec.add_dependency "rails", ">= 7.0", "< 7.3"
+  spec.add_dependency "rails", ">= 7.0", "< 8.1"
   spec.add_dependency "relation_to_struct", ">= 1.5.1"
   spec.add_dependency "ruby2_keywords"
 end


### PR DESCRIPTION
Also:

- Remove Ruby 3.1 from build matrix
- Use `~>` syntax in appraisal definitions such that we pull in the latest patch versions of Rails when the tests run

~~We'll want https://github.com/jcoleman/relation_to_struct/pull/23 to be merged and released first~~

Closes https://github.com/braintree/pg_ha_migrations/issues/109