### PR TITLE
Remove unsafe_partman_create_parent

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,23 +399,7 @@ safe_partman_create_parent :table,
   premake: 10,
   start_partition: Time.current + 1.month,
   infinite_time_partitions: false,
-  inherit_privileges: false
-```
-
-#### unsafe\_partman\_create\_parent
-
-We have chosen to flag the use of `retention` and `retention_keep_table` as an unsafe operation.
-While we recognize that these options are useful, we think they fit in the same category as `drop_table` and `rename_table`, and are therefore unsafe from an application perspective.
-If you wish to define these options, you must use this method.
-
-```ruby
-safe_create_partitioned_table :table, type: :range, partition_key: :created_at do |t|
-  t.timestamps null: false
-end
-
-unsafe_partman_create_parent :table,
-  partition_key: :created_at,
-  interval: "weekly",
+  inherit_privileges: false,
   retention: "60 days",
   retention_keep_table: false
 ```
@@ -423,7 +407,7 @@ unsafe_partman_create_parent :table,
 #### safe\_partman\_update\_config
 
 There are some partitioning options that cannot be set in the call to `create_parent` and are only available in the `part_config` table.
-As mentioned previously, you can specify these args in the call to `safe_partman_create_parent` or `unsafe_partman_create_parent` which will be delegated to this method.
+As mentioned previously, you can specify these args in the call to `safe_partman_create_parent` which will be delegated to this method.
 Calling this method directly will be useful if you need to modify your partitioned table after the fact.
 
 Allowed keyword args:
@@ -445,8 +429,9 @@ safe_partman_update_config :table,
 
 #### unsafe\_partman\_update\_config
 
-As with creating a partman parent table, we have chosen to flag the use of `retention` and `retention_keep_table` as an unsafe operation.
-If you wish to define these options, you must use this method.
+We have chosen to flag the use of `retention` and `retention_keep_table` as an unsafe operation.
+While we recognize that these options are useful, changing these values fits in the same category as `drop_table` and `rename_table`, and is therefore unsafe from an application perspective.
+If you wish to change these options, you must use this method.
 
 ```ruby
 unsafe_partman_update_config :table,

--- a/lib/pg_ha_migrations/unsafe_statements.rb
+++ b/lib/pg_ha_migrations/unsafe_statements.rb
@@ -118,6 +118,30 @@ module PgHaMigrations::UnsafeStatements
     execute_ancestor_statement(:add_index, table, column_names, **options)
   end
 
+  def unsafe_partman_update_config(table, **options)
+    invalid_options = options.keys - PgHaMigrations::PARTMAN_UPDATE_CONFIG_OPTIONS
+
+    raise ArgumentError, "Unrecognized argument(s): #{invalid_options}" unless invalid_options.empty?
+
+    PgHaMigrations::PartmanConfig.schema = _quoted_partman_schema
+
+    config = PgHaMigrations::PartmanConfig.find(_fully_qualified_table_name_for_partman(table))
+
+    if !options[:automatic_maintenance].nil?
+      options[:automatic_maintenance] = options[:automatic_maintenance] ? "on" : "off"
+    end
+
+    config.assign_attributes(**options)
+
+    inherit_privileges_changed = config.inherit_privileges_changed?
+
+    say_with_time "partman_update_config(#{table.inspect}, #{options.map { |k,v| "#{k}: #{v.inspect}" }.join(", ")})" do
+      config.save!
+    end
+
+    safe_partman_reapply_privileges(table) if inherit_privileges_changed
+  end
+
   ruby2_keywords def execute_ancestor_statement(method_name, *args, &block)
     # Dispatching here is a bit complicated: we need to execute the method
     # belonging to the first member of the inheritance chain (besides

--- a/spec/safe_statements_spec.rb
+++ b/spec/safe_statements_spec.rb
@@ -3344,49 +3344,13 @@ RSpec.describe PgHaMigrations::SafeStatements do
         end
 
         describe "safe_partman_create_parent" do
-          it "raises error when retention is set" do
-            migration = Class.new(migration_klass).new
-
-            expect(migration).to_not receive(:unsafe_partman_create_parent)
-
-            expect do
-              migration.safe_partman_create_parent(:foos3, retention: "60 days")
-            end.to raise_error(
-              PgHaMigrations::UnsafeMigrationError,
-              /:retention and\/or :retention_keep_table => false can potentially result in data loss if misconfigured/
-            )
-          end
-
-          it "raises error when retention_keep_table is set" do
-            migration = Class.new(migration_klass).new
-
-            expect(migration).to_not receive(:unsafe_partman_create_parent)
-
-            expect do
-              migration.safe_partman_create_parent(:foos3, retention_keep_table: false)
-            end.to raise_error(
-              PgHaMigrations::UnsafeMigrationError,
-              /:retention and\/or :retention_keep_table => false can potentially result in data loss if misconfigured/
-            )
-          end
-
-          it "delegates to unsafe_partman_create_parent when potentially dangerous args are not set" do
-            migration = Class.new(migration_klass).new
-
-            expect(migration).to receive(:unsafe_partman_create_parent).with(:foos3, arg1: "foo", arg2: "bar")
-
-            migration.safe_partman_create_parent(:foos3, arg1: "foo", arg2: "bar")
-          end
-        end
-
-        describe "unsafe_partman_create_parent" do
           context "when extension not installed" do
             it "raises error" do
               create_range_partitioned_table(:foos3, migration_klass)
 
               migration = Class.new(migration_klass) do
                 def up
-                  unsafe_partman_create_parent :foos3, partition_key: :created_at, interval: "monthly"
+                  safe_partman_create_parent :foos3, partition_key: :created_at, interval: "monthly"
                 end
               end
 
@@ -3408,7 +3372,7 @@ RSpec.describe PgHaMigrations::SafeStatements do
 
               migration = Class.new(migration_klass) do
                 def up
-                  unsafe_partman_create_parent :foos3, partition_key: :created_at, interval: "monthly"
+                  safe_partman_create_parent :foos3, partition_key: :created_at, interval: "monthly"
                 end
               end
 
@@ -3450,7 +3414,7 @@ RSpec.describe PgHaMigrations::SafeStatements do
 
               migration = Class.new(migration_klass) do
                 def up
-                  unsafe_partman_create_parent :foos3, partition_key: :created_at, interval: "monthly"
+                  safe_partman_create_parent :foos3, partition_key: :created_at, interval: "monthly"
                 end
               end
 
@@ -3485,7 +3449,7 @@ RSpec.describe PgHaMigrations::SafeStatements do
                 self.current_time = Time.current
 
                 def up
-                  unsafe_partman_create_parent "public.foos3",
+                  safe_partman_create_parent "public.foos3",
                     partition_key: :created_at,
                     interval: "weekly",
                     template_table: "public.foos3_template",
@@ -3542,7 +3506,7 @@ RSpec.describe PgHaMigrations::SafeStatements do
 
               migration = Class.new(migration_klass) do
                 def up
-                  unsafe_partman_create_parent :foos3, partition_key: :created_at, interval: "monthly"
+                  safe_partman_create_parent :foos3, partition_key: :created_at, interval: "monthly"
                 end
               end
 
@@ -3564,7 +3528,7 @@ RSpec.describe PgHaMigrations::SafeStatements do
             it "raises error when partition key not present" do
               migration = Class.new(migration_klass) do
                 def up
-                  unsafe_partman_create_parent :foos3, partition_key: nil, interval: "monthly"
+                  safe_partman_create_parent :foos3, partition_key: nil, interval: "monthly"
                 end
               end
 
@@ -3576,7 +3540,7 @@ RSpec.describe PgHaMigrations::SafeStatements do
             it "raises error when interval not present" do
               migration = Class.new(migration_klass) do
                 def up
-                  unsafe_partman_create_parent :foos3, partition_key: :created_at, interval: nil
+                  safe_partman_create_parent :foos3, partition_key: :created_at, interval: nil
                 end
               end
 
@@ -3588,7 +3552,7 @@ RSpec.describe PgHaMigrations::SafeStatements do
             it "raises error when unsupported optional arg is supplied" do
               migration = Class.new(migration_klass) do
                 def up
-                  unsafe_partman_create_parent :foos3, partition_key: :created_at, interval: "monthly", foo: "bar"
+                  safe_partman_create_parent :foos3, partition_key: :created_at, interval: "monthly", foo: "bar"
                 end
               end
 
@@ -3600,7 +3564,7 @@ RSpec.describe PgHaMigrations::SafeStatements do
             it "raises error when on Postgres < 11" do
               migration = Class.new(migration_klass) do
                 def up
-                  unsafe_partman_create_parent :foos3, partition_key: :created_at, interval: "monthly"
+                  safe_partman_create_parent :foos3, partition_key: :created_at, interval: "monthly"
                 end
               end
 
@@ -3614,7 +3578,7 @@ RSpec.describe PgHaMigrations::SafeStatements do
             it "raises error when parent table does not exist" do
               migration = Class.new(migration_klass) do
                 def up
-                  unsafe_partman_create_parent :foos3, partition_key: :created_at, interval: "monthly"
+                  safe_partman_create_parent :foos3, partition_key: :created_at, interval: "monthly"
                 end
               end
 
@@ -3626,7 +3590,7 @@ RSpec.describe PgHaMigrations::SafeStatements do
             it "raises error when parent table does not exist and fully qualified name provided" do
               migration = Class.new(migration_klass) do
                 def up
-                  unsafe_partman_create_parent "public.foos3", partition_key: :created_at, interval: "monthly"
+                  safe_partman_create_parent "public.foos3", partition_key: :created_at, interval: "monthly"
                 end
               end
 
@@ -3640,7 +3604,7 @@ RSpec.describe PgHaMigrations::SafeStatements do
 
               migration = Class.new(migration_klass) do
                 def up
-                  unsafe_partman_create_parent :foos3, partition_key: :created_at, interval: "monthly", template_table: :foos3_template
+                  safe_partman_create_parent :foos3, partition_key: :created_at, interval: "monthly", template_table: :foos3_template
                 end
               end
 
@@ -3654,7 +3618,7 @@ RSpec.describe PgHaMigrations::SafeStatements do
 
               migration = Class.new(migration_klass) do
                 def up
-                  unsafe_partman_create_parent :foos3, partition_key: :created_at, interval: "monthly", template_table: "public.foos3_template"
+                  safe_partman_create_parent :foos3, partition_key: :created_at, interval: "monthly", template_table: "public.foos3_template"
                 end
               end
 
@@ -3677,7 +3641,7 @@ RSpec.describe PgHaMigrations::SafeStatements do
 
               migration = Class.new(migration_klass) do
                 def up
-                  unsafe_partman_create_parent :foos3, partition_key: :created_at, interval: "monthly"
+                  safe_partman_create_parent :foos3, partition_key: :created_at, interval: "monthly"
                 end
               end
 
@@ -3700,7 +3664,7 @@ RSpec.describe PgHaMigrations::SafeStatements do
 
               migration = Class.new(migration_klass) do
                 def up
-                  unsafe_partman_create_parent "foos3'", partition_key: :created_at, interval: "monthly"
+                  safe_partman_create_parent "foos3'", partition_key: :created_at, interval: "monthly"
                 end
               end
 
@@ -3712,7 +3676,7 @@ RSpec.describe PgHaMigrations::SafeStatements do
             it "raises error when invalid type used for start partition" do
               migration = Class.new(migration_klass) do
                 def up
-                  unsafe_partman_create_parent :foos3, partition_key: :created_at, interval: "monthly", start_partition: "garbage"
+                  safe_partman_create_parent :foos3, partition_key: :created_at, interval: "monthly", start_partition: "garbage"
                 end
               end
 
@@ -3786,7 +3750,7 @@ RSpec.describe PgHaMigrations::SafeStatements do
 
               setup_migration = Class.new(migration_klass) do
                 def up
-                  unsafe_partman_create_parent :foos3, partition_key: :created_at, interval: "monthly"
+                  safe_partman_create_parent :foos3, partition_key: :created_at, interval: "monthly"
                 end
               end
 
@@ -3824,7 +3788,7 @@ RSpec.describe PgHaMigrations::SafeStatements do
 
               setup_migration = Class.new(migration_klass) do
                 def up
-                  unsafe_partman_create_parent :foos3,
+                  safe_partman_create_parent :foos3,
                     partition_key: :created_at,
                     interval: "monthly",
                     inherit_privileges: false,
@@ -3858,7 +3822,7 @@ RSpec.describe PgHaMigrations::SafeStatements do
 
               setup_migration = Class.new(migration_klass) do
                 def up
-                  unsafe_partman_create_parent :foos3, partition_key: :created_at, interval: "monthly"
+                  safe_partman_create_parent :foos3, partition_key: :created_at, interval: "monthly"
                 end
               end
 
@@ -3950,7 +3914,7 @@ RSpec.describe PgHaMigrations::SafeStatements do
 
               setup_migration = Class.new(migration_klass) do
                 def up
-                  unsafe_partman_create_parent :foos3, partition_key: :created_at, interval: "monthly"
+                  safe_partman_create_parent :foos3, partition_key: :created_at, interval: "monthly"
 
                   unsafe_execute(<<~SQL)
                     CREATE ROLE foo NOLOGIN;


### PR DESCRIPTION
I figured it would be a good time to do this as we're prepping for a 2.0 release. Configuring retention options on a brand new partitioned table doesn't feel like something that needs to be flagged as unsafe. _Changing_ these options after the table is in use does still feel unsafe and we continue to flag it as such.