### PR TITLE
Add nulls_not_distinct support to safe_add_concurrent_partitioned_index (alternate 1)

### DIFF
--- a/lib/pg_ha_migrations/safe_statements.rb
+++ b/lib/pg_ha_migrations/safe_statements.rb
@@ -217,7 +217,8 @@ module PgHaMigrations::SafeStatements
     using: nil,
     unique: nil,
     where: nil,
-    comment: nil
+    comment: nil,
+    nulls_not_distinct: nil
   )
 
     if ActiveRecord::Base.connection.postgresql_version < 11_00_00
@@ -252,6 +253,7 @@ module PgHaMigrations::SafeStatements
         using: using,
         unique: unique,
         where: where,
+        nulls_not_distinct: nulls_not_distinct,
         comment: comment,
         algorithm: :only, # see lib/pg_ha_migrations/hacks/add_index_on_only.rb
       )
@@ -273,6 +275,7 @@ module PgHaMigrations::SafeStatements
         using: using,
         unique: unique,
         where: where,
+        nulls_not_distinct: nulls_not_distinct,
       )
     end
 


### PR DESCRIPTION
This should be supported by default in the other `add_index` methods because we already accept generic `options`, but here we need to support it specially since we define kwargs.



Note: This and the other [alternate PR](https://github.com/braintree/pg_ha_migrations/pull/120) were authored with the assistance of different LLM support. I'd like reviewers to compare the two.