### PR TITLE
Add support for nulls_not_distinct option to index creation methods

### DIFF
--- a/spec/safe_statements_spec.rb
+++ b/spec/safe_statements_spec.rb
@@ -2425,39 +2425,7 @@ RSpec.describe PgHaMigrations::SafeStatements do
             expect(indexes).to be_empty
           end
 
-          it "raises error when nulls_not_distinct is provided but ActiveRecord < 7.1" do
-            skip "Only relevant in ActiveRecord versions that don't supports it" if ActiveRecord.gem_version >= Gem::Version.new("7.1")
-            skip "Will raise a separately tested argument validation error when Postgres doesn't support it" if ActiveRecord::Base.connection.postgresql_version < 15_00_00
-
-            setup_migration = Class.new(migration_klass) do
-              def up
-                safe_create_table :foos
-                safe_add_column :foos, :bar, :text
-              end
-            end
-
-            setup_migration.suppress_messages { setup_migration.migrate(:up) }
-
-            test_migration = Class.new(migration_klass) do
-              def up
-                safe_add_index_on_empty_table :foos, :bar, nulls_not_distinct: true
-              end
-            end
-
-            # Temporarily mock the ActiveRecord version to be < 7.1
-            allow(ActiveRecord).to receive(:gem_version).and_return(Gem::Version.new("7.0.0"))
-
-            expect do
-              test_migration.suppress_messages { test_migration.migrate(:up) }
-            end.to raise_error(
-              PgHaMigrations::InvalidMigrationError,
-              "nulls_not_distinct option requires ActiveRecord 7.1 or higher"
-            )
-          end
-
           it "raises error when nulls_not_distinct is provided but PostgreSQL < 15" do
-            skip "Will raise a separately tested argument validation error when ActiveRecord doesn't supports it" if ActiveRecord.gem_version < Gem::Version.new("7.1")
-
             setup_migration = Class.new(migration_klass) do
               def up
                 safe_create_table :foos
@@ -2542,39 +2510,7 @@ RSpec.describe PgHaMigrations::SafeStatements do
             )
           end
 
-          it "raises error when nulls_not_distinct is provided but ActiveRecord < 7.1" do
-            skip "Only relevant in ActiveRecord versions that don't supports it" if ActiveRecord.gem_version >= Gem::Version.new("7.1")
-            skip "Will raise a separately tested argument validation error when Postgres doesn't support it" if ActiveRecord::Base.connection.postgresql_version < 15_00_00
-
-            setup_migration = Class.new(migration_klass) do
-              def up
-                safe_create_table :foos
-                safe_add_column :foos, :bar, :text
-              end
-            end
-
-            setup_migration.suppress_messages { setup_migration.migrate(:up) }
-
-            test_migration = Class.new(migration_klass) do
-              def up
-                safe_add_concurrent_index :foos, :bar, nulls_not_distinct: true
-              end
-            end
-
-            # Temporarily mock the ActiveRecord version to be < 7.1
-            allow(ActiveRecord).to receive(:gem_version).and_return(Gem::Version.new("7.0.0"))
-
-            expect do
-              test_migration.suppress_messages { test_migration.migrate(:up) }
-            end.to raise_error(
-              PgHaMigrations::InvalidMigrationError,
-              "nulls_not_distinct option requires ActiveRecord 7.1 or higher"
-            )
-          end
-
           it "raises error when nulls_not_distinct is provided but PostgreSQL < 15" do
-            skip "Will raise a separately tested argument validation error when ActiveRecord doesn't supports it" if ActiveRecord.gem_version < Gem::Version.new("7.1")
-
             setup_migration = Class.new(migration_klass) do
               def up
                 safe_create_table :foos
@@ -3341,7 +3277,6 @@ RSpec.describe PgHaMigrations::SafeStatements do
           end
 
           it "creates valid index with nulls_not_distinct when multiple child partitions exist" do
-            skip "Won't actually be able to create nulls_not_distinct indexes unless ActiveRecord supports it" if ActiveRecord.gem_version < Gem::Version.new("7.1")
             skip "Won't actually be able to create nulls_not_distinct indexes unless Postgres supports it" if ActiveRecord::Base.connection.postgresql_version < 15_00_00
 
             create_range_partitioned_table(:foos3, migration_klass, with_partman: true)
@@ -3384,36 +3319,7 @@ RSpec.describe PgHaMigrations::SafeStatements do
             end
           end
 
-          it "raises error when nulls_not_distinct is provided but ActiveRecord < 7.1" do
-            skip "Only relevant in ActiveRecord versions that don't supports it" if ActiveRecord.gem_version >= Gem::Version.new("7.1")
-            skip "Will raise a separately tested argument validation error when Postgres doesn't support it" if ActiveRecord::Base.connection.postgresql_version < 15_00_00
-
-            create_range_partitioned_table(:foos3, migration_klass, with_partman: true)
-
-            test_migration = Class.new(migration_klass) do
-              def up
-                safe_add_concurrent_partitioned_index(
-                  :foos3,
-                  :text_column,
-                  nulls_not_distinct: true
-                )
-              end
-            end
-
-            # Temporarily mock the ActiveRecord version to be < 7.1
-            allow(ActiveRecord).to receive(:gem_version).and_return(Gem::Version.new("7.0.0"))
-
-            expect do
-              test_migration.suppress_messages { test_migration.migrate(:up) }
-            end.to raise_error(
-              PgHaMigrations::InvalidMigrationError,
-              "nulls_not_distinct option requires ActiveRecord 7.1 or higher"
-            )
-          end
-
           it "raises error when nulls_not_distinct is provided but PostgreSQL < 15" do
-            skip "Will raise a separately tested argument validation error when ActiveRecord doesn't supports it" if ActiveRecord.gem_version < Gem::Version.new("7.1")
-
             create_range_partitioned_table(:foos3, migration_klass, with_partman: true)
 
             test_migration = Class.new(migration_klass) do

--- a/spec/safe_statements_spec.rb
+++ b/spec/safe_statements_spec.rb
@@ -2424,6 +2424,65 @@ RSpec.describe PgHaMigrations::SafeStatements do
             indexes = ActiveRecord::Base.connection.indexes("foos")
             expect(indexes).to be_empty
           end
+
+          it "raises error when nulls_not_distinct is provided but ActiveRecord < 7.1" do
+            skip "Only relevant in ActiveRecord versions that don't supports it" if ActiveRecord.gem_version >= Gem::Version.new("7.1")
+            skip "Will raise a separately tested argument validation error when Postgres doesn't support it" if ActiveRecord::Base.connection.postgresql_version < 15_00_00
+
+            setup_migration = Class.new(migration_klass) do
+              def up
+                safe_create_table :foos
+                safe_add_column :foos, :bar, :text
+              end
+            end
+
+            setup_migration.suppress_messages { setup_migration.migrate(:up) }
+
+            test_migration = Class.new(migration_klass) do
+              def up
+                safe_add_index_on_empty_table :foos, :bar, nulls_not_distinct: true
+              end
+            end
+
+            # Temporarily mock the ActiveRecord version to be < 7.1
+            allow(ActiveRecord).to receive(:gem_version).and_return(Gem::Version.new("7.0.0"))
+
+            expect do
+              test_migration.suppress_messages { test_migration.migrate(:up) }
+            end.to raise_error(
+              PgHaMigrations::InvalidMigrationError,
+              "nulls_not_distinct option requires ActiveRecord 7.1 or higher"
+            )
+          end
+
+          it "raises error when nulls_not_distinct is provided but PostgreSQL < 15" do
+            skip "Will raise a separately tested argument validation error when ActiveRecord doesn't supports it" if ActiveRecord.gem_version < Gem::Version.new("7.1")
+
+            setup_migration = Class.new(migration_klass) do
+              def up
+                safe_create_table :foos
+                safe_add_column :foos, :bar, :text
+              end
+            end
+
+            setup_migration.suppress_messages { setup_migration.migrate(:up) }
+
+            test_migration = Class.new(migration_klass) do
+              def up
+                safe_add_index_on_empty_table :foos, :bar, nulls_not_distinct: true
+              end
+            end
+
+            # Temporarily mock the PostgreSQL version to be < 15
+            allow(ActiveRecord::Base.connection).to receive(:postgresql_version).and_return(14_00_00)
+
+            expect do
+              test_migration.suppress_messages { test_migration.migrate(:up) }
+            end.to raise_error(
+              PgHaMigrations::InvalidMigrationError,
+              "nulls_not_distinct option requires PostgreSQL 15 or higher"
+            )
+          end
         end
 
         describe "#safe_add_concurrent_index" do
@@ -2480,6 +2539,65 @@ RSpec.describe PgHaMigrations::SafeStatements do
               table: "x" * 51,
               name: "idx_on_bar_d7a594ad66",
               columns: ["bar"],
+            )
+          end
+
+          it "raises error when nulls_not_distinct is provided but ActiveRecord < 7.1" do
+            skip "Only relevant in ActiveRecord versions that don't supports it" if ActiveRecord.gem_version >= Gem::Version.new("7.1")
+            skip "Will raise a separately tested argument validation error when Postgres doesn't support it" if ActiveRecord::Base.connection.postgresql_version < 15_00_00
+
+            setup_migration = Class.new(migration_klass) do
+              def up
+                safe_create_table :foos
+                safe_add_column :foos, :bar, :text
+              end
+            end
+
+            setup_migration.suppress_messages { setup_migration.migrate(:up) }
+
+            test_migration = Class.new(migration_klass) do
+              def up
+                safe_add_concurrent_index :foos, :bar, nulls_not_distinct: true
+              end
+            end
+
+            # Temporarily mock the ActiveRecord version to be < 7.1
+            allow(ActiveRecord).to receive(:gem_version).and_return(Gem::Version.new("7.0.0"))
+
+            expect do
+              test_migration.suppress_messages { test_migration.migrate(:up) }
+            end.to raise_error(
+              PgHaMigrations::InvalidMigrationError,
+              "nulls_not_distinct option requires ActiveRecord 7.1 or higher"
+            )
+          end
+
+          it "raises error when nulls_not_distinct is provided but PostgreSQL < 15" do
+            skip "Will raise a separately tested argument validation error when ActiveRecord doesn't supports it" if ActiveRecord.gem_version < Gem::Version.new("7.1")
+
+            setup_migration = Class.new(migration_klass) do
+              def up
+                safe_create_table :foos
+                safe_add_column :foos, :bar, :text
+              end
+            end
+
+            setup_migration.suppress_messages { setup_migration.migrate(:up) }
+
+            test_migration = Class.new(migration_klass) do
+              def up
+                safe_add_concurrent_index :foos, :bar, nulls_not_distinct: true
+              end
+            end
+
+            # Temporarily mock the PostgreSQL version to be < 15
+            allow(ActiveRecord::Base.connection).to receive(:postgresql_version).and_return(14_00_00)
+
+            expect do
+              test_migration.suppress_messages { test_migration.migrate(:up) }
+            end.to raise_error(
+              PgHaMigrations::InvalidMigrationError,
+              "nulls_not_distinct option requires PostgreSQL 15 or higher"
             )
           end
         end
@@ -3220,6 +3338,103 @@ RSpec.describe PgHaMigrations::SafeStatements do
             expect do
               test_migration.suppress_messages { test_migration.migrate(:up) }
             end.to raise_error(PgHaMigrations::InvalidMigrationError, "Concurrent partitioned index creation not supported on Postgres databases before version 11")
+          end
+
+          it "creates valid index with nulls_not_distinct when multiple child partitions exist" do
+            skip "Won't actually be able to create nulls_not_distinct indexes unless ActiveRecord supports it" if ActiveRecord.gem_version < Gem::Version.new("7.1")
+            skip "Won't actually be able to create nulls_not_distinct indexes unless Postgres supports it" if ActiveRecord::Base.connection.postgresql_version < 15_00_00
+
+            create_range_partitioned_table(:foos3, migration_klass, with_partman: true)
+
+            test_migration = Class.new(migration_klass) do
+              def up
+                safe_add_concurrent_partitioned_index(
+                  :foos3,
+                  :text_column,
+                  nulls_not_distinct: true
+                )
+              end
+            end
+
+            # Count child partitions to know exactly how many times the method will be called
+            child_tables = partitions_for_table(:foos3)
+            # +1 for the parent table itself
+            expected_calls = child_tables.size + 1
+
+            # Check that we pass the nulls_not_distinct option to the underlying add_index method
+            # exactly the right number of times (once for parent table + once for each child partition)
+            expect(ActiveRecord::Base.connection).to receive(:add_index).with(
+              anything,
+              anything,
+              hash_including(nulls_not_distinct: true)
+            ).exactly(expected_calls).times.and_call_original
+
+            test_migration.suppress_messages { test_migration.migrate(:up) }
+
+            # Verify the nulls_not_distinct property is actually set on the created indexes
+            tables_with_indexes = partitions_for_table(:foos3).unshift(:foos3)
+
+            tables_with_indexes.each do |table|
+              index_name = "index_#{table}_on_text_column"
+              index_def = ActiveRecord::Base.connection.indexes(table).find { |idx| idx.name == index_name }
+
+              expect(index_def).to be_present
+              expect(index_def.nulls_not_distinct).to be(true),
+                "Index '#{index_name}' on table '#{table}' does not have nulls_not_distinct set"
+            end
+          end
+
+          it "raises error when nulls_not_distinct is provided but ActiveRecord < 7.1" do
+            skip "Only relevant in ActiveRecord versions that don't supports it" if ActiveRecord.gem_version >= Gem::Version.new("7.1")
+            skip "Will raise a separately tested argument validation error when Postgres doesn't support it" if ActiveRecord::Base.connection.postgresql_version < 15_00_00
+
+            create_range_partitioned_table(:foos3, migration_klass, with_partman: true)
+
+            test_migration = Class.new(migration_klass) do
+              def up
+                safe_add_concurrent_partitioned_index(
+                  :foos3,
+                  :text_column,
+                  nulls_not_distinct: true
+                )
+              end
+            end
+
+            # Temporarily mock the ActiveRecord version to be < 7.1
+            allow(ActiveRecord).to receive(:gem_version).and_return(Gem::Version.new("7.0.0"))
+
+            expect do
+              test_migration.suppress_messages { test_migration.migrate(:up) }
+            end.to raise_error(
+              PgHaMigrations::InvalidMigrationError,
+              "nulls_not_distinct option requires ActiveRecord 7.1 or higher"
+            )
+          end
+
+          it "raises error when nulls_not_distinct is provided but PostgreSQL < 15" do
+            skip "Will raise a separately tested argument validation error when ActiveRecord doesn't supports it" if ActiveRecord.gem_version < Gem::Version.new("7.1")
+
+            create_range_partitioned_table(:foos3, migration_klass, with_partman: true)
+
+            test_migration = Class.new(migration_klass) do
+              def up
+                safe_add_concurrent_partitioned_index(
+                  :foos3,
+                  :text_column,
+                  nulls_not_distinct: true
+                )
+              end
+            end
+
+            # Temporarily mock the PostgreSQL version to be < 15
+            allow(ActiveRecord::Base.connection).to receive(:postgresql_version).and_return(14_00_00)
+
+            expect do
+              test_migration.suppress_messages { test_migration.migrate(:up) }
+            end.to raise_error(
+              PgHaMigrations::InvalidMigrationError,
+              "nulls_not_distinct option requires PostgreSQL 15 or higher"
+            )
           end
         end
 


### PR DESCRIPTION
This allows users to create indexes where NULL values are treated as equal
to each other rather than always being distinct, which can be useful for
certain uniqueness constraints.

Most of the `*_add_index` methods support this by default because we
already accept generic options, but in
`safe_add_concurrent_partitioned_index`  we need to support it specially
since we define kwargs instead of taking on `options` hash argument.

In all of the methods ActiveRecord defaults to simply dropping the
option on the floor when it is not supported by the database, which we
consider to be unsafe behavior, so we update all of the `safe_*` methods
to raise helpful errors when the required invariants don't hold.



Original LLM generated message for history:

```
This change adds support for PostgreSQL 15+'s `nulls_not_distinct` index option to all methods that add indexes in the pg_ha_migrations gem. Specifically:

- Updated `safe_add_concurrent_partitioned_index` method to accept the `nulls_not_distinct` parameter and pass it through to both parent and child index creation calls

- Added a test that verifies the option is properly passed to the underlying ActiveRecord methods and that the PostgreSQL-level `indnullsnotdistinct` flag is properly set in the database

This allows users to create indexes where NULL values are treated as equal to each other rather than always being distinct, which can be useful for certain uniqueness constraints.

The implementation maintains compatibility with existing code while adding support for this PostgreSQL 15+ feature.
```

Note: This and the other [alternate PR](https://github.com/braintree/pg_ha_migrations/pull/119) were authored with the assistance of different LLM support. I'd like reviewers to compare the two.