### PR TITLE
Add `safe_make_column_not_nullable_from_check_constraint` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,14 +189,17 @@ safe_make_column_nullable :table, :column
 ```
 #### safe\_make\_column\_not\_nullable
 
-Safely make the column not nullable - adds a temporary constraint and uses that constraint to validate no values are null before altering the column, then removes the temporary constraint
+Safely make the column not nullable - adds a temporary constraint and uses that constraint to validate no values are null before altering the column, then removes the temporary constraint.
 
 ```ruby
 safe_make_column_not_nullable :table, :column
 ```
 
-Note:
-This method runs multiple DDL statements non-transactionally. Validating the constraint could fail. In such cases an exception will be raised, and an INVALID constraint will be left on the table.
+> **Note:**
+> - This method performs a full table scan to validate that no NULL values exist in the column. While no exclusive lock is held for this scan, oon large tables the scan may take a long time.
+> - The method runs multiple DDL statements non-transactionally. Validating the constraint can fail. In such cases an exception will be raised, and an INVALID constraint will be left on the table.
+
+If you want to avoid a full table scan and have already added and validated a suitable CHECK constraint, consider using [`safe_make_column_not_nullable_from_check_constraint`](#safe_make_column_not_nullable_from_check_constraint) instead.
 
 #### unsafe\_make\_column\_not\_nullable
 
@@ -205,6 +208,23 @@ Unsafely make a column not nullable.
 ```ruby
 unsafe_make_column_not_nullable :table, :column
 ```
+
+#### safe\_make\_column\_not\_nullable\_from\_check\_constraint
+
+Variant of `safe_make_column_not_nullable` that safely makes a column NOT NULL using an existing validated CHECK constraint that enforces non-null values for the column. This method is expected to always be fast because it avoids a full table scan.
+
+```ruby
+safe_make_column_not_nullable_from_check_constraint :table, :column, constraint_name: :constraint_name
+```
+
+- `constraint_name` (required): The name of a validated CHECK constraint that enforces `column IS NOT NULL`.
+- `drop_constraint:` (optional, default: true): Whether to drop the constraint after making the column NOT NULL.
+
+You should use [`safe_make_column_not_nullable`](#safe_make_column_not_nullable_from_check_constraint) when neither a CHECK constraint or a NOT NULL constraint exists already. You should use this method when you already have an equivalent CHECK constraint on the table.
+
+This method will raise an error if the constraint does not exist, is not validated, or does not strictly enforce non-null values for the column.
+
+> **Note:**  We do not attempt to catch all possible proofs of `column IS NOT NULL` by means of an existing constraint; only a constraint with the exact definition `column IS NOT NULL` will be recognized.
 
 #### safe\_add\_index\_on\_empty\_table
 

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ safe_make_column_not_nullable :table, :column
 ```
 
 > **Note:**
-> - This method performs a full table scan to validate that no NULL values exist in the column. While no exclusive lock is held for this scan, oon large tables the scan may take a long time.
+> - This method performs a full table scan to validate that no NULL values exist in the column. While no exclusive lock is held for this scan, on large tables the scan may take a long time.
 > - The method runs multiple DDL statements non-transactionally. Validating the constraint can fail. In such cases an exception will be raised, and an INVALID constraint will be left on the table.
 
 If you want to avoid a full table scan and have already added and validated a suitable CHECK constraint, consider using [`safe_make_column_not_nullable_from_check_constraint`](#safe_make_column_not_nullable_from_check_constraint) instead.
@@ -220,7 +220,7 @@ safe_make_column_not_nullable_from_check_constraint :table, :column, constraint_
 - `constraint_name` (required): The name of a validated CHECK constraint that enforces `column IS NOT NULL`.
 - `drop_constraint:` (optional, default: true): Whether to drop the constraint after making the column NOT NULL.
 
-You should use [`safe_make_column_not_nullable`](#safe_make_column_not_nullable_from_check_constraint) when neither a CHECK constraint or a NOT NULL constraint exists already. You should use this method when you already have an equivalent CHECK constraint on the table.
+You should use [`safe_make_column_not_nullable`](#safe_make_column_not_nullable) when neither a CHECK constraint or a NOT NULL constraint exists already. You should use this method when you already have an equivalent CHECK constraint on the table.
 
 This method will raise an error if the constraint does not exist, is not validated, or does not strictly enforce non-null values for the column.
 

--- a/lib/pg_ha_migrations.rb
+++ b/lib/pg_ha_migrations.rb
@@ -71,6 +71,7 @@ module PgHaMigrations
   UndefinedTableError = Class.new(StandardError)
 end
 
+require "pg_ha_migrations/constraint"
 require "pg_ha_migrations/relation"
 require "pg_ha_migrations/blocking_database_transactions"
 require "pg_ha_migrations/blocking_database_transactions_reporter"

--- a/lib/pg_ha_migrations/constraint.rb
+++ b/lib/pg_ha_migrations/constraint.rb
@@ -1,0 +1,1 @@
+PgHaMigrations::CheckConstraint = Struct.new(:name, :definition, :validated)

--- a/lib/pg_ha_migrations/safe_statements.rb
+++ b/lib/pg_ha_migrations/safe_statements.rb
@@ -184,6 +184,13 @@ module PgHaMigrations::SafeStatements
       raise PgHaMigrations::InvalidMigrationError, "The provided constraint is not validated"
     end
 
+    # The constraint has to actually prove that no null values exist, so the
+    # constraint condition can't simply include the `IS NOT NULL` check. We
+    # don't try to handle all possible cases here. For example,
+    # `a IS NOT NULL AND b IS NOT NULL` would prove what we need, but it would
+    # be complicated to check. We must ensure, however, that we're not too
+    # loose. For example, `a IS NOT NULL OR b IS NOT NULL` would not prove that
+    # `a IS NOT NULL`.
     unless constraint.definition =~ /\ACHECK \(*(#{Regexp.escape(column.to_s)}|#{Regexp.escape(quoted_column_name)}) IS NOT NULL\)*\Z/i
       raise PgHaMigrations::InvalidMigrationError, "The provided constraint does not enforce non-null values for the column"
     end


### PR DESCRIPTION
This method allows safely making a column non-nullable using a validated check constraint, ensuring minimal locking and compatibility with PostgreSQL 12+. It confirms the existence and validation status of the provided constraint, raising helpful errors if either of those turn out not to be true.