### PR TITLE
Add idempotence and existing constraint re-use to safe_make_column_not_nullable

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,15 +187,15 @@ safe_make_column_nullable :table, :column
 ```
 #### safe\_make\_column\_not\_nullable
 
-Safely make the column not nullable - adds a temporary constraint and uses that constraint to validate no values are null before altering the column, then removes the temporary constraint.
+Safely make the column not nullable. This method uses a `CHECK column IS NOT NULL` constraint to validate no values are null before altering the column. If such a constraint exists already, it is re-used, if it does not, a temporary constraint is added. Whether or not the constraint already existed, the constraint will be validated, if necessary, and removed after the column is marked `NOT NULL`.
 
 ```ruby
 safe_make_column_not_nullable :table, :column
 ```
 
 > **Note:**
-> - This method performs a full table scan to validate that no NULL values exist in the column. While no exclusive lock is held for this scan, on large tables the scan may take a long time.
-> - The method runs multiple DDL statements non-transactionally. Validating the constraint can fail. In such cases an exception will be raised, and an INVALID constraint will be left on the table.
+> - This method may perform a full table scan to validate that no NULL values exist in the column. While no exclusive lock is held for this scan, on large tables the scan may take a long time.
+> - The method runs multiple DDL statements non-transactionally. Validating the constraint can fail. In such cases an INVALID constraint will be left on the table. Calling `safe_make_column_not_nullable` again is safe.
 
 If you want to avoid a full table scan and have already added and validated a suitable CHECK constraint, consider using [`safe_make_column_not_nullable_from_check_constraint`](#safe_make_column_not_nullable_from_check_constraint) instead.
 

--- a/lib/pg_ha_migrations/constraint.rb
+++ b/lib/pg_ha_migrations/constraint.rb
@@ -1,1 +1,8 @@
-PgHaMigrations::CheckConstraint = Struct.new(:name, :definition, :validated)
+PgHaMigrations::CheckConstraint = Struct.new(:name, :definition, :validated) do
+  def initialize(name, definition, validated)
+    # pg_get_constraintdef includes NOT VALID in the definition,
+    # but we return that as a separate attribute.
+    definition = definition&.gsub(/ NOT VALID\Z/, "")
+    super(name, definition, validated)
+  end
+end


### PR DESCRIPTION
If an existing constraint already exists we should re-use that. If it's not yet validated, we still need to validate it -- that gives use idempotency, and we no longer need to raise an error if the previous run failed. If the existing constraint is already validated, there's no need to validate it, and we can simply proceed.

While it's true that _if you already know you have a validated constraint_ we idiomatically prefer using
`safe_make_column_not_nullable_from_check_constraint` in cases where your database state might be unknown (e.g., a previous failure), it's still helpful to be able to use `safe_make_column_not_nullable`.

Fixes #130
Fixes #131