### PR TITLE
Make safe_add_concurrent_partitioned_index resumable after a partial failure

### DIFF
--- a/lib/pg_ha_migrations/safe_statements.rb
+++ b/lib/pg_ha_migrations/safe_statements.rb
@@ -346,7 +346,7 @@ module PgHaMigrations::SafeStatements
           AND pg_class.relname = ANY (ARRAY[#{quoted_child_index_names}])
       SQL
 
-      invalid_child_index_names.each do |child_index|
+      child_indexes.select { |n| invalid_child_index_names.include?(n) }.each do |child_index|
         safe_remove_concurrent_index(child_index.table.fully_qualified_name, name: child_index.name)
       end
     end

--- a/lib/pg_ha_migrations/safe_statements.rb
+++ b/lib/pg_ha_migrations/safe_statements.rb
@@ -346,9 +346,7 @@ module PgHaMigrations::SafeStatements
           AND pg_class.relname = ANY (ARRAY[#{quoted_child_index_names}])
       SQL
 
-      child_indexes.each do |child_index|
-        next unless invalid_child_index_names.include?(child_index.name)
-
+      invalid_child_index_names.each do |child_index|
         safe_remove_concurrent_index(child_index.table.fully_qualified_name, name: child_index.name)
       end
     end

--- a/lib/pg_ha_migrations/safe_statements.rb
+++ b/lib/pg_ha_migrations/safe_statements.rb
@@ -326,6 +326,33 @@ module PgHaMigrations::SafeStatements
       PgHaMigrations::Index.from_table_and_columns(child_table, columns)
     end
 
+    # A previous run that was interrupted mid-build can leave an invalid index
+    # behind on a child partition. Because CREATE INDEX ... IF NOT EXISTS matches
+    # on name only (not validity), that leftover would be skipped and never
+    # rebuilt, so the parent index would never become valid and this method
+    # would raise below on every re-run. When resuming (if_not_exists), drop any
+    # invalid child leftovers first so they get rebuilt. They are unattached at
+    # this point (the attach step runs only after every child index is built),
+    # so they can be dropped concurrently.
+    if if_not_exists && child_indexes.present?
+      quoted_child_index_names = child_indexes.map { |child_index| connection.quote(child_index.name) }.join(", ")
+
+      invalid_child_index_names = connection.select_values(<<~SQL)
+        SELECT pg_class.relname
+        FROM pg_index
+          JOIN pg_class ON pg_class.oid = pg_index.indexrelid
+        WHERE NOT pg_index.indisvalid
+          AND pg_class.relkind = 'i'
+          AND pg_class.relname = ANY (ARRAY[#{quoted_child_index_names}])
+      SQL
+
+      child_indexes.each do |child_index|
+        next unless invalid_child_index_names.include?(child_index.name)
+
+        safe_remove_concurrent_index(child_index.table.fully_qualified_name, name: child_index.name)
+      end
+    end
+
     # CREATE INDEX ON ONLY parent_table
     unsafe_add_index(
       parent_table.fully_qualified_name,

--- a/lib/pg_ha_migrations/safe_statements.rb
+++ b/lib/pg_ha_migrations/safe_statements.rb
@@ -346,7 +346,7 @@ module PgHaMigrations::SafeStatements
           AND pg_class.relname = ANY (ARRAY[#{quoted_child_index_names}])
       SQL
 
-      child_indexes.select { |n| invalid_child_index_names.include?(n) }.each do |child_index|
+      child_indexes.select { |index| invalid_child_index_names.include?(index.name) }.each do |child_index|
         safe_remove_concurrent_index(child_index.table.fully_qualified_name, name: child_index.name)
       end
     end

--- a/spec/safe_statements_spec.rb
+++ b/spec/safe_statements_spec.rb
@@ -1548,6 +1548,73 @@ RSpec.describe PgHaMigrations::SafeStatements do
           test_migration.suppress_messages { test_migration.migrate(:up) }
         end
 
+        it "rebuilds an invalid child index left by a previous run when if_not_exists is true" do
+          TestHelpers.create_range_partitioned_table(:foos3, migration_klass)
+
+          ActiveRecord::Base.connection.execute(<<~SQL)
+            CREATE TABLE foos3_child1 PARTITION OF foos3
+            FOR VALUES FROM ('2020-01-01') TO ('2020-02-01');
+
+            CREATE TABLE foos3_child2 PARTITION OF foos3
+            FOR VALUES FROM ('2020-02-01') TO ('2020-03-01');
+          SQL
+
+          # Simulate a run that was interrupted after child1's index was built
+          # and attached but while child2's concurrent build was still running:
+          # child2 is left with an invalid, unattached index, so the parent
+          # ON ONLY index is invalid too.
+          setup_migration = Class.new(migration_klass) do
+            def up
+              unsafe_add_index :foos3, :updated_at, algorithm: :only
+              unsafe_add_index :foos3_child1, :updated_at
+
+              unsafe_execute(<<~SQL)
+                ALTER INDEX index_foos3_on_updated_at
+                ATTACH PARTITION index_foos3_child1_on_updated_at
+              SQL
+
+              unsafe_add_index :foos3_child2, :updated_at
+
+              unsafe_execute(<<~SQL)
+                UPDATE pg_index SET indisvalid = false
+                WHERE indexrelid = 'index_foos3_child2_on_updated_at'::regclass
+              SQL
+            end
+          end
+
+          setup_migration.suppress_messages { setup_migration.migrate(:up) }
+
+          expect(ActiveRecord::Base.pluck_from_sql("SELECT indexrelid::regclass::text FROM pg_index WHERE NOT indisvalid")).to contain_exactly(
+            "index_foos3_on_updated_at",
+            "index_foos3_child2_on_updated_at",
+          )
+
+          test_migration = Class.new(migration_klass) do
+            def up
+              safe_add_concurrent_partitioned_index :foos3, :updated_at, if_not_exists: true
+            end
+          end
+
+          test_migration.suppress_messages { test_migration.migrate(:up) }
+
+          aggregate_failures do
+            # the invalid leftover was dropped and rebuilt; every index is valid now
+            expect(ActiveRecord::Base.pluck_from_sql("SELECT indexrelid::regclass::text FROM pg_index WHERE NOT indisvalid")).to be_empty
+
+            %i[foos3 foos3_child1 foos3_child2].each do |table|
+              indexes = ActiveRecord::Base.connection.indexes(table)
+
+              expect(indexes.size).to eq(1)
+              expect(indexes.first).to have_attributes(
+                table: table,
+                name: "index_#{table}_on_updated_at",
+                columns: ["updated_at"],
+                using: :btree,
+              )
+            end
+          end
+        end
+
         it "creates valid index when table / index name use non-standard characters" do
           TestHelpers.create_range_partitioned_table("foos3'", migration_klass)
 


### PR DESCRIPTION
## Problem

`safe_add_concurrent_partitioned_index(..., if_not_exists: true)` is documented/intended to be resumable, but it is **not** resumable after a run that fails partway through building the per-partition indexes.

When a `CREATE INDEX CONCURRENTLY` on one partition dies (statement timeout, lock timeout, connection drop, deploy interruption…), it leaves an **unattached, `indisvalid = false`** index behind on that child partition. On the next run:

1. The parent `ON ONLY` create (`IF NOT EXISTS`) is skipped by name — fine.
2. For the child, `CREATE INDEX CONCURRENTLY IF NOT EXISTS <name>` matches on **name only** — Postgres never checks index validity — so the invalid leftover is skipped and **never rebuilt**.
3. The attach step attaches the still-invalid child, so the parent `ON ONLY` index never becomes valid.
4. The method hits its final assertion and raises `"Unexpected state. Parent index ... is invalid"`.

Because nothing rebuilds the invalid child, this raises on **every** subsequent run — the migration never converges without manual `DROP INDEX` cleanup.

The existing "creates valid index when partially created" spec only exercises the case where children are *missing* (which `IF NOT EXISTS` rebuilds fine); an *invalid* leftover child is a different, uncovered case.

## Fix

When resuming with `if_not_exists`, drop any invalid child index leftovers before the (re)build so they get rebuilt and the parent can validate. The invalid children are guaranteed **unattached** at this point — the attach step runs only after every child index has been built — so they can be dropped concurrently via the existing `safe_remove_concurrent_index`. The detection matches the exact child index names for the current partitions (and `relkind = 'i'`, so sub-partition parent indexes are left to the recursive call), and is a single catalog query gated on `if_not_exists`, so the non-resume paths are unchanged.

## Test

Adds a spec that simulates the real failure state (one child valid + attached, one child built-but-invalid + unattached, parent invalid) and asserts that a re-run with `if_not_exists: true` drops the invalid leftover, rebuilds it, and converges to a fully valid parent index. Without the fix this spec fails with the exact `"Parent index ... is invalid"` raise.

## Verification

Ran the affected `#safe_add_concurrent_partitioned_index` suite locally against the project's `docker compose` Postgres 18 / pg_partman 5 image (`bundle exec rspec spec/safe_statements_spec.rb -e safe_add_concurrent_partitioned_index`), green across all `ActiveRecord::Migration::Compatibility` versions. Confirmed the new spec is red without the change and green with it. CI matrix will exercise the full PG/partman/Rails grid.
